### PR TITLE
feat(document): T-IFC-001 to T-IFC-007 — IFC 2x3/4 import/export, round-trip, property sets, performance

### DIFF
--- a/packages/document/src/ifc.test.ts
+++ b/packages/document/src/ifc.test.ts
@@ -1,0 +1,482 @@
+/**
+ * IFC Import/Export Tests
+ * T-IFC-001 through T-IFC-007
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  IFCParser,
+  IFCSerializer,
+  parseIFC,
+  serializeIFC,
+  IFC4Parser,
+  parsePropertySets,
+  type IFCPropertySet,
+} from './ifc';
+import { createProject } from './document';
+
+// ─── Shared fixtures ──────────────────────────────────────────────────────────
+
+function ifc2x3Fixture(): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');",
+    "FILE_NAME('test.ifc','20240101T000000',('$'),('$'),('$'),'IFC2x3','');",
+    "FILE_SCHEMA(('IFC2X3'));",
+    'ENDSEC;',
+    'DATA;',
+    "#1=IFCPROJECT('abc1',$,'Test Project',$,$,$,$,$,$);",
+    "#10=IFCBUILDING('bld1',$,'Building',$,$,#100,$,$,$);",
+    "#100=IFCBUILDINGSTOREY('sty1',$,'Ground Floor',$,$,#200,$,$,$);",
+    "#2=IFCWALL('wall1',$,'External Wall',$,$,#100,$,$,$);",
+    "#3=IFCDOOR('door1',$,'Front Door',$,$,#2,$,$,$);",
+    "#4=IFCWINDOW('win1',$,'Window 1',$,$,#2,$,$,$,$);",
+    "#5=IFCSLAB('slab1',$,'Ground Slab',$,$,$,$,$,$);",
+    "#6=IFCCOLUMN('col1',$,'Column A1',$,$,$,$,$);",
+    "#7=IFCBEAM('beam1',$,'Beam B1',$,$,$,$,$);",
+    "#8=IFCSPACE('sp1',$,'Room 101',$,$,$,$,$,$);",
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+  ].join('\n');
+}
+
+function ifc4Fixture(): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION(('ViewDefinition [ReferenceView]'),'2;1');",
+    "FILE_NAME('test4.ifc','20240101T000000',('$'),('$'),('$'),'IFC4','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    "#1=IFCPROJECT('p1',$,'IFC4 Project',$,$,$,$,$,$);",
+    // NURBS curve (IFCRATIONALBSPLINECURVEWITHKNOTS)
+    '#10=IFCRATIONALBSPLINECURVEWITHKNOTS(3,(#11,#12,#13),.UNSPECIFIED.,.F.,.F.,(4,4),(0.,1.),.UNSPECIFIED.,(1.,1.,1.));',
+    '#11=IFCCARTESIANPOINT((0.,0.,0.));',
+    '#12=IFCCARTESIANPOINT((50.,100.,0.));',
+    '#13=IFCCARTESIANPOINT((100.,0.,0.));',
+    // CSG solid
+    "#20=IFCBOOLEANRESULT(.DIFFERENCE.,#21,#22);",
+    '#21=IFCEXTRUDEDAREASOLID(#23,#24,#25,3000.);',
+    '#22=IFCEXTRUDEDAREASOLID(#26,#27,#28,1000.);',
+    "#30=IFCWALL('w4',$,'IFC4 Wall',$,$,$,$,$,$);",
+    "#31=IFCDOOR('d4',$,'IFC4 Door',$,$,$,$,$,$);",
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+  ].join('\n');
+}
+
+function psetFixture(): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_SCHEMA(('IFC2X3'));",
+    'ENDSEC;',
+    'DATA;',
+    "#1=IFCWALL('w1',$,'Wall with Psets',$,$,$,$,$,$);",
+    "#50=IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('1hr'),$);",
+    "#51=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);",
+    "#52=IFCPROPERTYSINGLEVALUE('LoadBearing',$,IFCBOOLEAN(.T.),$);",
+    "#53=IFCPROPERTYSET('pset1',$,'Pset_WallCommon',$,(#50,#51,#52));",
+    "#60=IFCPROPERTYSINGLEVALUE('UValue',$,IFCREAL(0.25),$);",
+    "#61=IFCPROPERTYSET('pset2',$,'Pset_ThermalProperties',$,(#60));",
+    "#70=IFCRELDEFINESBYPROPERTIES('r1',$,$,$,(#1),(#53));",
+    "#71=IFCRELDEFINESBYPROPERTIES('r2',$,$,$,(#1),(#61));",
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+  ].join('\n');
+}
+
+// ─── T-IFC-001: IFC 2x3 Import ───────────────────────────────────────────────
+
+describe('T-IFC-001: IFC 2x3 Import', () => {
+  it('should parse IFC 2x3 format and detect schema', () => {
+    const parser = new IFCParser(ifc2x3Fixture());
+    const result = parser.parse();
+    expect(result.schema).toBe('IFC2X3');
+  });
+
+  it('should map all IFC entity types to OpenCAD element types', () => {
+    const parser = new IFCParser(ifc2x3Fixture());
+    const { entities } = parser.parse();
+    const types = entities.map((e) => e.elementType);
+    expect(types).toContain('wall');
+    expect(types).toContain('door');
+    expect(types).toContain('window');
+    expect(types).toContain('slab');
+    expect(types).toContain('column');
+    expect(types).toContain('beam');
+    expect(types).toContain('space');
+  });
+
+  it('should preserve IFC hierarchy (building storey reference)', () => {
+    const parser = new IFCParser(ifc2x3Fixture());
+    const { entities } = parser.parse();
+    const wall = entities.find((e) => e.name === 'External Wall');
+    expect(wall).toBeDefined();
+    // storey reference #100 should be captured
+    expect(wall?.storeyRef).toBe('#100');
+  });
+
+  it('should import to DocumentSchema with all entities as elements', () => {
+    const doc = parseIFC(ifc2x3Fixture());
+    const elements = Object.values(doc.elements);
+    // wall, door, window, slab, column, beam, space = 7
+    expect(elements.length).toBeGreaterThanOrEqual(7);
+  });
+});
+
+// ─── T-IFC-002: IFC 4 Import ─────────────────────────────────────────────────
+
+describe('T-IFC-002: IFC 4 Import', () => {
+  it('should parse IFC 4 format and detect schema', () => {
+    const parser = new IFC4Parser(ifc4Fixture());
+    const result = parser.parse();
+    expect(result.schema).toBe('IFC4');
+  });
+
+  it('should handle NURBS curves (IFCRATIONALBSPLINECURVEWITHKNOTS)', () => {
+    const parser = new IFC4Parser(ifc4Fixture());
+    const { geometryEntities } = parser.parse();
+    const nurbs = geometryEntities.find((g) => g.type === 'NURBS');
+    expect(nurbs).toBeDefined();
+    expect(nurbs?.controlPoints?.length).toBe(3);
+  });
+
+  it('should handle CSG geometry (IFCBOOLEANRESULT)', () => {
+    const parser = new IFC4Parser(ifc4Fixture());
+    const { geometryEntities } = parser.parse();
+    const csg = geometryEntities.find((g) => g.type === 'CSG');
+    expect(csg).toBeDefined();
+    expect(csg?.operation).toBe('DIFFERENCE');
+  });
+
+  it('should import IFC 4 elements to DocumentSchema', () => {
+    const doc = parseIFC(ifc4Fixture());
+    const elements = Object.values(doc.elements);
+    expect(elements.length).toBeGreaterThanOrEqual(2); // wall + door
+  });
+});
+
+// ─── T-IFC-003: IFC 2x3 Export ───────────────────────────────────────────────
+
+describe('T-IFC-003: IFC 2x3 Export', () => {
+  it('should export valid IFC 2x3 with required header', () => {
+    const project = createProject('Export Test', 'tester');
+    const ifc = serializeIFC(project, { schema: 'IFC2X3' });
+    expect(ifc).toContain('ISO-10303-21');
+    expect(ifc).toContain("FILE_SCHEMA(('IFC2X3'))");
+    expect(ifc).toContain('DATA;');
+    expect(ifc).toContain('ENDSEC;');
+    expect(ifc).toContain('END-ISO-10303-21;');
+  });
+
+  it('should include all required IFC header entities', () => {
+    const project = createProject('Cert Test', 'tester');
+    const ifc = serializeIFC(project, { schema: 'IFC2X3' });
+    expect(ifc).toContain('FILE_DESCRIPTION');
+    expect(ifc).toContain('FILE_NAME');
+    expect(ifc).toContain('FILE_SCHEMA');
+  });
+
+  it('should export IFCWALLSTANDARDCASE for wall elements', () => {
+    const project = createProject('Wall Test', 'tester');
+    const layerId = Object.keys(project.layers)[0];
+    const levelId = Object.keys(project.levels)[0];
+    const wallId = crypto.randomUUID();
+    project.elements[wallId] = {
+      id: wallId,
+      type: 'wall',
+      properties: { Name: { type: 'string', value: 'South Wall' } },
+      propertySets: [],
+      geometry: { type: 'brep', data: null },
+      layerId,
+      levelId,
+      transform: {
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+      boundingBox: {
+        min: { x: 0, y: 0, z: 0, _type: 'Point3D' },
+        max: { x: 1, y: 0.3, z: 3, _type: 'Point3D' },
+      },
+      metadata: {
+        id: wallId,
+        createdBy: 'test',
+        createdAt: 0,
+        updatedAt: 0,
+        version: { clock: {} },
+      },
+      visible: true,
+      locked: false,
+    };
+
+    const ifc = serializeIFC(project, { schema: 'IFC2X3' });
+    expect(ifc).toContain('IFCWALLSTANDARDCASE');
+    expect(ifc).toContain('South Wall');
+  });
+});
+
+// ─── T-IFC-004: IFC 4 Export ─────────────────────────────────────────────────
+
+describe('T-IFC-004: IFC 4 Export', () => {
+  it('should export with IFC4 schema declaration', () => {
+    const project = createProject('IFC4 Export', 'tester');
+    const ifc = serializeIFC(project, { schema: 'IFC4' });
+    expect(ifc).toContain("FILE_SCHEMA(('IFC4'))");
+  });
+
+  it('should use IFCWALL (not IFCWALLSTANDARDCASE) for IFC4', () => {
+    const project = createProject('IFC4 Wall', 'tester');
+    const layerId = Object.keys(project.layers)[0];
+    const levelId = Object.keys(project.levels)[0];
+    const wallId = crypto.randomUUID();
+    project.elements[wallId] = {
+      id: wallId,
+      type: 'wall',
+      properties: { Name: { type: 'string', value: 'IFC4 Wall' } },
+      propertySets: [],
+      geometry: { type: 'brep', data: null },
+      layerId,
+      levelId,
+      transform: {
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+      boundingBox: {
+        min: { x: 0, y: 0, z: 0, _type: 'Point3D' },
+        max: { x: 1, y: 0.3, z: 3, _type: 'Point3D' },
+      },
+      metadata: {
+        id: wallId,
+        createdBy: 'test',
+        createdAt: 0,
+        updatedAt: 0,
+        version: { clock: {} },
+      },
+      visible: true,
+      locked: false,
+    };
+
+    const ifc = serializeIFC(project, { schema: 'IFC4' });
+    // IFC4 uses IFCWALL not IFCWALLSTANDARDCASE
+    expect(ifc).toMatch(/IFCWALL[^S]/);
+  });
+});
+
+// ─── T-IFC-005: IFC Round-trip ────────────────────────────────────────────────
+
+describe('T-IFC-005: IFC Round-trip', () => {
+  it('should export then re-import preserving element count', () => {
+    const project = createProject('Round-trip', 'tester');
+    const layerId = Object.keys(project.layers)[0];
+    const levelId = Object.keys(project.levels)[0];
+
+    // Add a wall
+    const wallId = crypto.randomUUID();
+    project.elements[wallId] = {
+      id: wallId,
+      type: 'wall',
+      properties: { Name: { type: 'string', value: 'RT Wall' } },
+      propertySets: [],
+      geometry: { type: 'brep', data: null },
+      layerId,
+      levelId,
+      transform: {
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+      boundingBox: {
+        min: { x: 0, y: 0, z: 0, _type: 'Point3D' },
+        max: { x: 5000, y: 300, z: 3000, _type: 'Point3D' },
+      },
+      metadata: {
+        id: wallId,
+        createdBy: 'test',
+        createdAt: 0,
+        updatedAt: 0,
+        version: { clock: {} },
+      },
+      visible: true,
+      locked: false,
+    };
+
+    const exported = serializeIFC(project);
+    const reimported = parseIFC(exported);
+    const elements = Object.values(reimported.elements);
+
+    expect(elements.length).toBe(Object.values(project.elements).length);
+  });
+
+  it('should preserve element names through round-trip', () => {
+    const project = createProject('RT Name', 'tester');
+    const layerId = Object.keys(project.layers)[0];
+    const levelId = Object.keys(project.levels)[0];
+    const wallId = crypto.randomUUID();
+    project.elements[wallId] = {
+      id: wallId,
+      type: 'wall',
+      properties: { Name: { type: 'string', value: 'Named Wall' } },
+      propertySets: [],
+      geometry: { type: 'brep', data: null },
+      layerId,
+      levelId,
+      transform: {
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+      boundingBox: {
+        min: { x: 0, y: 0, z: 0, _type: 'Point3D' },
+        max: { x: 1, y: 1, z: 1, _type: 'Point3D' },
+      },
+      metadata: {
+        id: wallId,
+        createdBy: 'test',
+        createdAt: 0,
+        updatedAt: 0,
+        version: { clock: {} },
+      },
+      visible: true,
+      locked: false,
+    };
+
+    const exported = serializeIFC(project);
+    const reimported = parseIFC(exported);
+    const elements = Object.values(reimported.elements);
+    const names = elements.map((e) => e.properties['Name']?.value);
+    expect(names).toContain('Named Wall');
+  });
+
+  it('should preserve bounding box within 0.1mm tolerance', () => {
+    const project = createProject('RT Geo', 'tester');
+    const layerId = Object.keys(project.layers)[0];
+    const levelId = Object.keys(project.levels)[0];
+    const wallId = crypto.randomUUID();
+    const bbox = {
+      min: { x: 100.0, y: 200.0, z: 0.0, _type: 'Point3D' as const },
+      max: { x: 5100.0, y: 500.0, z: 3000.0, _type: 'Point3D' as const },
+    };
+    project.elements[wallId] = {
+      id: wallId,
+      type: 'wall',
+      properties: { Name: { type: 'string', value: 'Geo Wall' } },
+      propertySets: [],
+      geometry: { type: 'brep', data: null },
+      layerId,
+      levelId,
+      transform: {
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+      boundingBox: bbox,
+      metadata: {
+        id: wallId,
+        createdBy: 'test',
+        createdAt: 0,
+        updatedAt: 0,
+        version: { clock: {} },
+      },
+      visible: true,
+      locked: false,
+    };
+
+    const exported = serializeIFC(project);
+    const reimported = parseIFC(exported);
+    const el = Object.values(reimported.elements).find(
+      (e) => e.properties['Name']?.value === 'Geo Wall'
+    );
+    expect(el).toBeDefined();
+    // Bounding box should be preserved within 0.1mm
+    const tolerance = 0.1;
+    expect(Math.abs((el?.boundingBox.min.x ?? 0) - bbox.min.x)).toBeLessThanOrEqual(tolerance);
+    expect(Math.abs((el?.boundingBox.max.x ?? 0) - bbox.max.x)).toBeLessThanOrEqual(tolerance);
+    expect(Math.abs((el?.boundingBox.max.z ?? 0) - bbox.max.z)).toBeLessThanOrEqual(tolerance);
+  });
+});
+
+// ─── T-IFC-006: IFC Property Sets ────────────────────────────────────────────
+
+describe('T-IFC-006: IFC Property Sets', () => {
+  it('should parse Pset_ elements', () => {
+    const psets = parsePropertySets(psetFixture());
+    expect(psets.length).toBeGreaterThanOrEqual(2);
+    expect(psets.map((p) => p.name)).toContain('Pset_WallCommon');
+    expect(psets.map((p) => p.name)).toContain('Pset_ThermalProperties');
+  });
+
+  it('should extract individual properties from Pset', () => {
+    const psets = parsePropertySets(psetFixture());
+    const wallCommon = psets.find((p) => p.name === 'Pset_WallCommon');
+    expect(wallCommon).toBeDefined();
+    const props = wallCommon?.properties ?? {};
+    expect(props['FireRating']).toBe('1hr');
+  });
+
+  it('should associate Psets with the correct element', () => {
+    const psets = parsePropertySets(psetFixture());
+    const wallCommon = psets.find((p) => p.name === 'Pset_WallCommon');
+    // element ref #1 (IFCWALL w1) should be in relatedObjects
+    expect(wallCommon?.relatedObjectRefs).toContain('#1');
+  });
+
+  it('should import Psets into element propertySets on parseIFC', () => {
+    const doc = parseIFC(psetFixture());
+    const elements = Object.values(doc.elements);
+    const wall = elements.find((e) => e.type === 'wall');
+    expect(wall?.propertySets.length).toBeGreaterThan(0);
+    const psetNames = wall?.propertySets.map((ps) => ps.name) ?? [];
+    expect(psetNames).toContain('Pset_WallCommon');
+  });
+});
+
+// ─── T-IFC-007: Large IFC Import Performance ─────────────────────────────────
+
+describe('T-IFC-007: Large IFC Import Performance', () => {
+  function generateLargeIFC(entityCount: number): string {
+    const lines = [
+      'ISO-10303-21;',
+      'HEADER;',
+      "FILE_SCHEMA(('IFC2X3'));",
+      'ENDSEC;',
+      'DATA;',
+    ];
+    for (let i = 1; i <= entityCount; i++) {
+      lines.push(
+        `#${i}=IFCWALL('wall${i}',$,'Wall ${i}',$,$,$,$,$,$);`
+      );
+    }
+    lines.push('ENDSEC;', 'END-ISO-10303-21;');
+    return lines.join('\n');
+  }
+
+  it('should parse 10,000 entities without error', () => {
+    const content = generateLargeIFC(10_000);
+    const parser = new IFCParser(content);
+    const { entities } = parser.parse();
+    expect(entities.length).toBe(10_000);
+  });
+
+  it('should parse 10,000 entities within 5 seconds', () => {
+    const content = generateLargeIFC(10_000);
+    const start = Date.now();
+    const parser = new IFCParser(content);
+    parser.parse();
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(5_000); // 5s for 10k entities, scaled from 500MB/30s
+  });
+
+  it('should import 1,000 entities into DocumentSchema within 2 seconds', () => {
+    const content = generateLargeIFC(1_000);
+    const start = Date.now();
+    const doc = parseIFC(content);
+    const elapsed = Date.now() - start;
+    expect(Object.values(doc.elements).length).toBe(1_000);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});

--- a/packages/document/src/ifc.ts
+++ b/packages/document/src/ifc.ts
@@ -1,18 +1,52 @@
 /**
  * IFC Import/Export
  * IFC file format support for Open BIM interoperability
+ * Supports IFC 2x3 and IFC 4
  */
 
 import { DocumentSchema, ElementSchema, ElementType } from './types';
 
-interface ParsedIFCEntity {
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ParsedIFCEntity {
   id: string;
   type: string;
   name: string;
   elementType: ElementType;
   attributes: Record<string, string>;
   guid?: string;
+  storeyRef?: string;
+  rawLine?: string;
 }
+
+export interface ParsedGeometryEntity {
+  id: string;
+  type: 'NURBS' | 'CSG' | 'EXTRUSION' | 'OTHER';
+  operation?: string;
+  controlPoints?: Array<{ x: number; y: number; z: number }>;
+  degree?: number;
+  operandRefs?: string[];
+}
+
+export interface IFCParseResult {
+  schema: string;
+  entities: ParsedIFCEntity[];
+  geometryEntities: ParsedGeometryEntity[];
+  warnings: string[];
+}
+
+export interface IFCPropertySet {
+  id: string;
+  name: string;
+  properties: Record<string, string | number | boolean>;
+  relatedObjectRefs: string[];
+}
+
+export interface SerializeOptions {
+  schema?: 'IFC2X3' | 'IFC4';
+}
+
+// ─── Entity type mappings ─────────────────────────────────────────────────────
 
 const IFC_ENTITY_MAP: Record<string, ElementType> = {
   IFCWALL: 'wall',
@@ -29,68 +63,174 @@ const IFC_ENTITY_MAP: Record<string, ElementType> = {
   IFCANNOTATION: 'annotation',
 };
 
+// ─── IFCParser (2x3 and base) ─────────────────────────────────────────────────
+
 export class IFCParser {
-  private content: string;
+  protected content: string;
 
   constructor(content: string) {
     this.content = content;
   }
 
-  parse(): { entities: ParsedIFCEntity[]; warnings: string[] } {
-    const entities: ParsedIFCEntity[] = [];
-    const warnings: string[] = [];
+  parse(): IFCParseResult {
+    const schema = this._extractSchema();
+    const entities = this._parseEntities();
+    const geometryEntities = this._parseGeometryEntities();
+    return { schema, entities, geometryEntities, warnings: [] };
+  }
 
-    // Match IFC entities with their attributes - handles various IFC formats
-    // Format: #id=TYPE('guid',$,'name',...);
-    const entityRegex = /#(\d+)=(\w+)\s*\((?:'[^']*',\s*\$,\s*'([^']*)'|[^)]*)\)/gi;
+  protected _extractSchema(): string {
+    const m = this.content.match(/FILE_SCHEMA\s*\(\s*\(\s*'([^']+)'\s*\)\s*\)/i);
+    return m ? m[1].toUpperCase() : 'IFC2X3';
+  }
+
+  protected _parseEntities(): ParsedIFCEntity[] {
+    const entities: ParsedIFCEntity[] = [];
+    // Match: #id=TYPE(...)
+    const entityRegex = /#(\d+)\s*=\s*([A-Z]+)\s*\(([^)]*(?:\([^)]*\)[^)]*)*)\)/gi;
     let match;
 
     while ((match = entityRegex.exec(this.content)) !== null) {
-      const [, id, type] = match;
+      const [fullMatch, id, type] = match;
       const upperType = type.toUpperCase();
 
-      // Extract name from the full match
-      const nameMatch = match[0].match(/'([^']+)'/g);
-      const name = nameMatch && nameMatch.length > 1 ? nameMatch[1].replace(/'/g, '') : upperType;
+      if (!IFC_ENTITY_MAP[upperType]) continue;
 
-      if (IFC_ENTITY_MAP[upperType]) {
-        entities.push({
-          id: `#${id}`,
-          type: upperType,
-          name: name || upperType,
-          elementType: IFC_ENTITY_MAP[upperType],
-          attributes: {},
-        });
-      }
+      const args = match[3];
+
+      // First argument is typically GUID in quotes
+      const guidMatch = args.match(/^'([^']+)'/);
+      const guid = guidMatch ? guidMatch[1] : undefined;
+
+      // Third non-$ argument is typically the name
+      const nameMatch = fullMatch.match(/'[^']*',\s*\$,\s*'([^']+)'/);
+      const name = nameMatch ? nameMatch[1] : upperType;
+
+      // Find storey reference — last #ref in arg list
+      const storeyRefMatch = args.match(/,\s*(#\d+)\s*,/g);
+      const storeyRef = storeyRefMatch
+        ? storeyRefMatch[storeyRefMatch.length - 1].replace(/[,\s]/g, '')
+        : undefined;
+
+      entities.push({
+        id: `#${id}`,
+        type: upperType,
+        name,
+        elementType: IFC_ENTITY_MAP[upperType],
+        attributes: {},
+        guid,
+        storeyRef,
+        rawLine: fullMatch,
+      });
     }
 
-    return { entities, warnings };
+    return entities;
+  }
+
+  protected _parseGeometryEntities(): ParsedGeometryEntity[] {
+    return [];
   }
 }
 
+// ─── IFC4Parser ──────────────────────────────────────────────────────────────
+
+export class IFC4Parser extends IFCParser {
+  constructor(content: string) {
+    super(content);
+  }
+
+  parse(): IFCParseResult {
+    const schema = this._extractSchema();
+    const entities = this._parseEntities();
+    const geometryEntities = this._parseGeometryEntities();
+    return { schema, entities, geometryEntities, warnings: [] };
+  }
+
+  protected _parseGeometryEntities(): ParsedGeometryEntity[] {
+    const geos: ParsedGeometryEntity[] = [];
+    this._parseNURBS(geos);
+    this._parseCSG(geos);
+    return geos;
+  }
+
+  private _parseNURBS(out: ParsedGeometryEntity[]): void {
+    // Match IFCRATIONALBSPLINECURVEWITHKNOTS(degree,(#refs),...)
+    const re =
+      /#(\d+)\s*=\s*IFCRATIONALBSPLINECURVEWITHKNOTS\s*\((\d+)\s*,\s*\(([^)]+)\)/gi;
+    let m;
+    while ((m = re.exec(this.content)) !== null) {
+      const [, id, degreeStr, refs] = m;
+      const degree = parseInt(degreeStr, 10);
+      // Collect cartesian point refs
+      const ptRefs = refs.match(/#\d+/g) ?? [];
+      const controlPoints = ptRefs
+        .map((ref) => this._getCartesianPoint(ref))
+        .filter((p): p is { x: number; y: number; z: number } => p !== null);
+
+      out.push({
+        id: `#${id}`,
+        type: 'NURBS',
+        degree,
+        controlPoints,
+      });
+    }
+  }
+
+  private _parseCSG(out: ParsedGeometryEntity[]): void {
+    // Match IFCBOOLEANRESULT(.OP.,#A,#B)
+    const re = /#(\d+)\s*=\s*IFCBOOLEANRESULT\s*\(\s*\.(\w+)\.\s*,\s*(#\d+)\s*,\s*(#\d+)\s*\)/gi;
+    let m;
+    while ((m = re.exec(this.content)) !== null) {
+      const [, id, op, opA, opB] = m;
+      out.push({
+        id: `#${id}`,
+        type: 'CSG',
+        operation: op,
+        operandRefs: [opA, opB],
+      });
+    }
+  }
+
+  private _getCartesianPoint(ref: string): { x: number; y: number; z: number } | null {
+    // Match: #N=IFCCARTESIANPOINT((x.,y.,z.));
+    const id = ref.slice(1);
+    const re = new RegExp(
+      `#${id}\\s*=\\s*IFCCARTESIANPOINT\\s*\\(\\s*\\(([^)]+)\\)\\s*\\)`,
+      'i'
+    );
+    const m = this.content.match(re);
+    if (!m) return null;
+    const coords = m[1].split(',').map((s) => parseFloat(s.trim()));
+    return { x: coords[0] ?? 0, y: coords[1] ?? 0, z: coords[2] ?? 0 };
+  }
+}
+
+// ─── IFCSerializer ────────────────────────────────────────────────────────────
+
 export class IFCSerializer {
   private document: DocumentSchema;
+  private schema: 'IFC2X3' | 'IFC4';
   private lineNumber: number = 1;
 
-  constructor(document: DocumentSchema) {
+  constructor(document: DocumentSchema, options: SerializeOptions = {}) {
     this.document = document;
+    this.schema = options.schema ?? 'IFC2X3';
   }
 
   serialize(): string {
     const lines: string[] = [];
 
-    lines.push(...this.generateHeader());
+    lines.push(...this._generateHeader());
     lines.push('DATA;');
 
-    const elements = Object.values(this.document.elements);
     const levels = Object.values(this.document.levels);
-
     levels.forEach((level) => {
-      lines.push(...this.serializeLevel(level.id));
+      lines.push(...this._serializeLevel(level.id));
     });
 
+    const elements = Object.values(this.document.elements);
     elements.forEach((element) => {
-      lines.push(...this.serializeElement(element));
+      lines.push(...this._serializeElement(element));
     });
 
     lines.push('ENDSEC;');
@@ -99,72 +239,172 @@ export class IFCSerializer {
     return lines.join('\n');
   }
 
-  private generateHeader(): string[] {
+  private _generateHeader(): string[] {
     const now = new Date();
     const timestamp = now.toISOString().replace(/[-:]/g, '').split('.')[0];
 
     return [
       'ISO-10303-21;',
       'HEADER;',
-      'FILE_DESCRIPTION(($ . $), $ . $);',
-      `FILE_NAME('${this.document.name}.ifc','${timestamp}',('$'),('$'),('$'),'$','$','$');`,
-      'FILE_SCHEMA(($ . $));',
+      "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');",
+      `FILE_NAME('${this.document.name}.ifc','${timestamp}',('$'),('$'),('$'),'${this.schema}','');`,
+      `FILE_SCHEMA(('${this.schema}'));`,
       'ENDSEC;',
     ];
   }
 
-  private serializeLevel(id: string): string[] {
+  private _serializeLevel(id: string): string[] {
     const level = this.document.levels[id];
     if (!level) return [];
 
     const lineNum = this.lineNumber++;
-    return [`#${lineNum}=IFCBUILDINGSTOREY('${id}',$,'${level.name}',$,$,#${lineNum + 1},$);`];
+    return [
+      `#${lineNum}=IFCBUILDINGSTOREY('${id}',$,'${level.name}',$,$,#${lineNum + 1},$,$,$);`,
+    ];
   }
 
-  private serializeElement(element: ElementSchema): string[] {
+  private _serializeElement(element: ElementSchema): string[] {
     const lineNum = this.lineNumber++;
-    const ifcType = getIFCType(element.type);
-    const name = (element.properties.Name?.value as string) || 'Unnamed';
+    const ifcType = this._getIFCType(element.type);
+    const name = (element.properties['Name']?.value as string) || 'Unnamed';
+    const bbox = element.boundingBox;
 
-    return [`#${lineNum}=${ifcType}('${element.id}',$,'${name}',$,$,$,$,$,$);`];
+    // Embed bounding box as comment for round-trip fidelity
+    const bboxStr = `/* bbox:${bbox.min.x},${bbox.min.y},${bbox.min.z}:${bbox.max.x},${bbox.max.y},${bbox.max.z} */`;
+
+    return [`#${lineNum}=${ifcType}('${element.id}',$,'${name}',$,$,$,$,$,$); ${bboxStr}`];
+  }
+
+  private _getIFCType(elementType: ElementType): string {
+    if (this.schema === 'IFC4') {
+      const map4: Partial<Record<ElementType, string>> = {
+        wall: 'IFCWALL',
+        door: 'IFCDOOR',
+        window: 'IFCWINDOW',
+        slab: 'IFCSLAB',
+        roof: 'IFCROOF',
+        column: 'IFCCOLUMN',
+        beam: 'IFCBEAM',
+        stair: 'IFCSTAIR',
+        railing: 'IFCRAILING',
+        space: 'IFCSPACE',
+      };
+      if (map4[elementType]) return map4[elementType]!;
+    }
+
+    const map: Record<ElementType, string> = {
+      wall: 'IFCWALLSTANDARDCASE',
+      door: 'IFCDOOR',
+      window: 'IFCWINDOW',
+      slab: 'IFCSLAB',
+      roof: 'IFCROOF',
+      column: 'IFCCOLUMN',
+      beam: 'IFCBEAM',
+      stair: 'IFCSTAIR',
+      railing: 'IFCRAILING',
+      space: 'IFCSPACE',
+      annotation: 'IFCANNOTATION',
+      dimension: 'IFCANNOTATION',
+      grid: 'IFCANNOTATION',
+      line: 'IFCANNOTATION',
+      circle: 'IFCANNOTATION',
+      arc: 'IFCANNOTATION',
+      polyline: 'IFCANNOTATION',
+      surface: 'IFCANNOTATION',
+      solid: 'IFCSOLID',
+      point: 'IFCANNOTATION',
+      text: 'IFCTEXT',
+      block_ref: 'IFCBLOCK',
+      ellipse: 'IFCANNOTATION',
+      component: 'IFCGROUP',
+      group: 'IFCGROUP',
+    };
+
+    return map[elementType] || 'IFCANNOTATION';
   }
 }
 
-function getIFCType(elementType: ElementType): string {
-  const map: Record<ElementType, string> = {
-    wall: 'IFCWALLSTANDARDCASE',
-    door: 'IFCDOOR',
-    window: 'IFCWINDOW',
-    slab: 'IFCSLAB',
-    roof: 'IFCROOF',
-    column: 'IFCCOLUMN',
-    beam: 'IFCBEAM',
-    stair: 'IFCSTAIR',
-    railing: 'IFCRAILING',
-    space: 'IFCSPACE',
-    annotation: 'IFCANNOTATION',
-    dimension: 'IFCANNOTATION',
-    grid: 'IFCANNOTATION',
-    line: 'IFCANNOTATION',
-    circle: 'IFCANNOTATION',
-    arc: 'IFCANNOTATION',
-    polyline: 'IFCANNOTATION',
-    surface: 'IFCANNOTATION',
-    solid: 'IFCSOLID',
-    point: 'IFCANNOTATION',
-    text: 'IFCTEXT',
-    block_ref: 'IFCBLOCK',
-    ellipse: 'IFCANNOTATION',
-    component: 'IFCGROUP',
-    group: 'IFCGROUP',
-  };
+// ─── Property set parsing ─────────────────────────────────────────────────────
 
-  return map[elementType] || 'IFCANNOTATION';
+export function parsePropertySets(content: string): IFCPropertySet[] {
+  const psets: IFCPropertySet[] = [];
+
+  // Parse individual property values first: #id=IFCPROPERTYSINGLEVALUE('name',$,value,$)
+  const propValues: Record<string, { name: string; value: string | number | boolean }> = {};
+  const propRe =
+    /#(\d+)\s*=\s*IFCPROPERTYSINGLEVALUE\s*\(\s*'([^']+)'\s*,\s*\$\s*,\s*([^,]+)/gi;
+  let pm;
+  while ((pm = propRe.exec(content)) !== null) {
+    const [, id, name, rawVal] = pm;
+    let value: string | number | boolean = rawVal.trim();
+    // IFCLABEL('...')
+    const lblMatch = value.match(/IFCLABEL\('([^']*)'\)/i);
+    if (lblMatch) {
+      value = lblMatch[1];
+    }
+    // IFCBOOLEAN(.T.) or .F.
+    else if (/IFCBOOLEAN\(\.T\.\)/i.test(value as string) || value === '.T.') {
+      value = true;
+    } else if (/IFCBOOLEAN\(\.F\.\)/i.test(value as string) || value === '.F.') {
+      value = false;
+    }
+    // IFCREAL(n) or IFCINTEGER(n)
+    else {
+      const numMatch = (value as string).match(/IFC(?:REAL|INTEGER|NUMERIC)\(([^)]+)\)/i);
+      if (numMatch) value = parseFloat(numMatch[1]);
+    }
+    propValues[`#${id}`] = { name, value };
+  }
+
+  // Parse property sets: #id=IFCPROPERTYSET('guid',$,'Pset_Name',$,(#refs...))
+  const psetRe =
+    /#(\d+)\s*=\s*IFCPROPERTYSET\s*\(\s*'[^']*'\s*,\s*\$\s*,\s*'([^']+)'\s*,\s*\$\s*,\s*\(([^)]+)\)/gi;
+  let psm;
+  while ((psm = psetRe.exec(content)) !== null) {
+    const [, id, name, refsStr] = psm;
+    const refs = (refsStr.match(/#\d+/g) ?? []);
+    const properties: Record<string, string | number | boolean> = {};
+    for (const ref of refs) {
+      const pv = propValues[ref];
+      if (pv) properties[pv.name] = pv.value;
+    }
+    psets.push({
+      id: `#${id}`,
+      name,
+      properties,
+      relatedObjectRefs: [],
+    });
+  }
+
+  // Parse relations: #id=IFCRELDEFINESBYPROPERTIES('...',$,$,$,(#objRefs...),(#psetRef))
+  const relRe =
+    /#(\d+)\s*=\s*IFCRELDEFINESBYPROPERTIES\s*\(\s*'[^']*'\s*,\s*\$\s*,\s*\$\s*,\s*\$\s*,\s*\(([^)]+)\)\s*,\s*\(([^)]+)\)\s*\)/gi;
+  let rm;
+  while ((rm = relRe.exec(content)) !== null) {
+    const [, , objRefsStr, psetRefsStr] = rm;
+    const objRefs = (objRefsStr.match(/#\d+/g) ?? []);
+    const psetRefs = (psetRefsStr.match(/#\d+/g) ?? []);
+    for (const psetRef of psetRefs) {
+      const pset = psets.find((p) => p.id === psetRef);
+      if (pset) {
+        pset.relatedObjectRefs.push(...objRefs);
+      }
+    }
+  }
+
+  return psets;
 }
+
+// ─── Convenience functions ────────────────────────────────────────────────────
 
 export function parseIFC(content: string): DocumentSchema {
-  const parser = new IFCParser(content);
+  const schemaMatch = content.match(/FILE_SCHEMA\s*\(\s*\(\s*'([^']+)'\s*\)\s*\)/i);
+  const schema = schemaMatch ? schemaMatch[1].toUpperCase() : 'IFC2X3';
+
+  const parser = schema === 'IFC4' ? new IFC4Parser(content) : new IFCParser(content);
   const { entities } = parser.parse();
+
+  const psets = parsePropertySets(content);
 
   const defaultLayerId = crypto.randomUUID();
   const defaultLevelId = crypto.randomUUID();
@@ -206,15 +446,72 @@ export function parseIFC(content: string): DocumentSchema {
     },
   };
 
+  // Build entity id → psets lookup
+  const entityPsets: Record<string, IFCPropertySet[]> = {};
+  for (const pset of psets) {
+    for (const ref of pset.relatedObjectRefs) {
+      if (!entityPsets[ref]) entityPsets[ref] = [];
+      entityPsets[ref].push(pset);
+    }
+  }
+
   entities.forEach((entity) => {
     const elementId = crypto.randomUUID();
+
+    // Extract bounding box from serialized comment (round-trip support)
+    // The serializer embeds: /* bbox:x1,y1,z1:x2,y2,z2 */ on the same line as the entity
+    // Search by GUID to find the right line, then extract the bbox comment
+    const bboxMatch = entity.guid
+      ? (() => {
+          const lineRe = new RegExp(
+            String.raw`#\d+=` +
+            entity.type.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+            String.raw`\('` +
+            entity.guid.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+            String.raw`'[^\n]*bbox:([\d.+-]+),([\d.+-]+),([\d.+-]+):([\d.+-]+),([\d.+-]+),([\d.+-]+)`
+          );
+          return content.match(lineRe);
+        })()
+      : null;
+    const bbox = bboxMatch
+      ? {
+          min: {
+            x: parseFloat(bboxMatch[1] ?? '0'),
+            y: parseFloat(bboxMatch[2] ?? '0'),
+            z: parseFloat(bboxMatch[3] ?? '0'),
+            _type: 'Point3D' as const,
+          },
+          max: {
+            x: parseFloat(bboxMatch[4] ?? '0'),
+            y: parseFloat(bboxMatch[5] ?? '0'),
+            z: parseFloat(bboxMatch[6] ?? '0'),
+            _type: 'Point3D' as const,
+          },
+        }
+      : {
+          min: { x: 0, y: 0, z: 0, _type: 'Point3D' as const },
+          max: { x: 0, y: 0, z: 0, _type: 'Point3D' as const },
+        };
+
+    // Get psets associated with this entity's IFC id
+    const elementPsets = (entityPsets[entity.id] ?? []).map((ps) => {
+      const propRecord: Record<string, { type: 'string' | 'number' | 'boolean'; value: string | number | boolean }> = {};
+      for (const [propName, propVal] of Object.entries(ps.properties)) {
+        propRecord[propName] = {
+          type: typeof propVal === 'boolean' ? 'boolean' : typeof propVal === 'number' ? 'number' : 'string',
+          value: propVal,
+        };
+      }
+      return { id: ps.id, name: ps.name, properties: propRecord };
+    });
+
     document.elements[elementId] = {
       id: elementId,
       type: entity.elementType,
       properties: {
         Name: { type: 'string', value: entity.name },
       },
-      propertySets: [],
+      propertySets: elementPsets,
       geometry: { type: 'brep', data: null },
       layerId: defaultLayerId,
       levelId: defaultLevelId,
@@ -223,10 +520,7 @@ export function parseIFC(content: string): DocumentSchema {
         rotation: { x: 0, y: 0, z: 0 },
         scale: { x: 1, y: 1, z: 1 },
       },
-      boundingBox: {
-        min: { x: 0, y: 0, z: 0, _type: 'Point3D' },
-        max: { x: 0, y: 0, z: 0, _type: 'Point3D' },
-      },
+      boundingBox: bbox,
       metadata: {
         id: elementId,
         createdBy: 'ifc-import',
@@ -242,7 +536,7 @@ export function parseIFC(content: string): DocumentSchema {
   return document;
 }
 
-export function serializeIFC(document: DocumentSchema): string {
-  const serializer = new IFCSerializer(document);
+export function serializeIFC(document: DocumentSchema, options: SerializeOptions = {}): string {
+  const serializer = new IFCSerializer(document, options);
   return serializer.serialize();
 }


### PR DESCRIPTION
## Summary

- **T-IFC-001**: IFC 2x3 import with schema detection, full entity mapping, hierarchy preservation
- **T-IFC-002**: IFC 4 import with `IFC4Parser` supporting NURBS curves and CSG Boolean operations
- **T-IFC-003**: IFC 2x3 export with correct `FILE_SCHEMA`, header entities, `IFCWALLSTANDARDCASE`
- **T-IFC-004**: IFC 4 export with schema-aware entity names (`IFCWALL` vs `IFCWALLSTANDARDCASE`)
- **T-IFC-005**: Round-trip fidelity — element count, names, and bounding box within 0.1mm tolerance
- **T-IFC-006**: Property set parsing — `Pset_` extraction, property values, element association via `IFCRELDEFINESBYPROPERTIES`
- **T-IFC-007**: Performance — 10k entities parsed in < 5s; 1k element import in < 2s

## Test plan

- [x] 70 tests passing in `packages/document` (47 existing + 23 new IFC tests)
- [x] Full typecheck passes
- [x] All acceptance criteria covered

Closes #67
Closes #68
Closes #69
Closes #70
Closes #71
Closes #72
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)