### PR TITLE
chore: update all domain references to opencad.archi

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at:
 
-- **Email:** conduct@opencad.org
+- **Email:** conduct@opencad.archi
 - **Discord:** Report to any @Moderator or @Maintainer
 - **GitHub:** Contact any maintainer directly via GitHub DMs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -474,7 +474,7 @@ Before creating a new ADR, discuss in a GitHub Issue first.
 | [GitHub Discussions](https://github.com/CariHQ/opencad/discussions) | Questions, ideas, showcase |
 | [GitHub Issues](https://github.com/CariHQ/opencad/issues) | Bugs, feature requests |
 | [Discord](https://discord.gg/opencad) | Real-time chat |
-| [Community Calls](https://calendar.opencad.org) | Monthly video meetup |
+| [Community Calls](https://calendar.opencad.archi) | Monthly video meetup |
 
 ### Governance
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -276,8 +276,8 @@ OpenCAD was founded in April 2026 with the mission to make professional architec
 ## Contact
 
 - **Governance questions:** Open a [GitHub Discussion](https://github.com/CariHQ/opencad/discussions) with the `governance` label
-- **Private matters:** Contact the Lead Maintainer at [lead@opencad.org](mailto:lead@opencad.org)
-- **Code of Conduct:** [conduct@opencad.org](mailto:conduct@opencad.org)
+- **Private matters:** Contact the Lead Maintainer at [lead@opencad.archi](mailto:lead@opencad.archi)
+- **Code of Conduct:** [conduct@opencad.archi](mailto:conduct@opencad.archi)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ OpenCAD combines the accessibility of Figma (browser-native, WASM, real-time col
 
 ### Browser (No Install)
 
-Visit [app.opencad.org](https://app.opencad.org) — works immediately in Chrome, Firefox, Safari, or Edge.
+Visit [opencad.archi](https://opencad.archi) — works immediately in Chrome, Firefox, Safari, or Edge.
 
 ### Desktop
 
@@ -81,8 +81,8 @@ See [Self-Hosting Guide](docs/guides/self-hosting.md) for detailed setup.
 
 | Resource | Link |
 |----------|------|
-| **User Guide** | [docs.opencad.org](https://docs.opencad.org) |
-| **API Reference** | [api.opencad.org](https://api.opencad.org) |
+| **User Guide** | [docs.opencad.archi](https://docs.opencad.archi) |
+| **API Reference** | [api.opencad.archi](https://api.opencad.archi) |
 | **Contributing Guide** | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | **Product Requirements** | [PRD.md](PRD.md) |
 | **Architecture Docs** | [docs/architecture/](docs/architecture/) |
@@ -171,7 +171,7 @@ OpenCAD follows a [meritocratic governance model](GOVERNANCE.md). Decisions are 
 |---------|---------|
 | [GitHub Discussions](https://github.com/CariHQ/opencad/discussions) | Questions, ideas, showcase |
 | [Discord](https://discord.gg/opencad) | Real-time chat |
-| [Community Calls](https://calendar.opencad.org) | Monthly video meetup |
+| [Community Calls](https://calendar.opencad.archi) | Monthly video meetup |
 
 ## 🙏 Acknowledgments
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Instead, report them via one of these methods:
 
 ### Alternative: Email
 
-Send details to **security@opencad.org** with:
+Send details to **security@opencad.archi** with:
 
 - **Subject:** `[SECURITY] Brief description of the vulnerability`
 - **Body:** Detailed description including:
@@ -120,8 +120,8 @@ We do not currently offer a monetary bug bounty program. However, we do provide:
 
 ## Security Contact
 
-- **Email:** security@opencad.org
-- **PGP Key:** Available at https://opencad.org/.well-known/security.txt
+- **Email:** security@opencad.archi
+- **PGP Key:** Available at https://opencad.archi/.well-known/security.txt
 - **OpenPGP Fingerprint:** `XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX`
 
 ---

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,10 +10,10 @@ This document describes how to get help with OpenCAD.
 
 | Resource | Best For | Link |
 |----------|----------|------|
-| **Documentation** | How-to guides, feature reference | [docs.opencad.org](https://docs.opencad.org) |
+| **Documentation** | How-to guides, feature reference | [docs.opencad.archi](https://docs.opencad.archi) |
 | **GitHub Discussions** | Questions, discussions, showcase | [Discussions](https://github.com/CariHQ/opencad/discussions) |
 | **Discord** | Real-time chat, quick questions | [discord.gg/opencad](https://discord.gg/opencad) |
-| **Community Calls** | Monthly video meetup, demos | [calendar.opencad.org](https://calendar.opencad.org) |
+| **Community Calls** | Monthly video meetup, demos | [calendar.opencad.archi](https://calendar.opencad.archi) |
 
 ### For Contributors
 
@@ -21,7 +21,7 @@ This document describes how to get help with OpenCAD.
 |----------|----------|------|
 | **Contributing Guide** | How to contribute | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | **Architecture Docs** | Technical design decisions | [docs/architecture/](docs/architecture/) |
-| **API Documentation** | Code-level reference | [api.opencad.org](https://api.opencad.org) |
+| **API Documentation** | Code-level reference | [api.opencad.archi](https://api.opencad.archi) |
 | **Good First Issues** | Beginner-friendly tasks | [GitHub Issues](https://github.com/CariHQ/opencad/labels/good%20first%20issue) |
 
 ---
@@ -124,7 +124,7 @@ For organizations needing dedicated support:
 - **Training** — On-site or remote training sessions
 - **Consulting** — Architecture review, migration assistance
 
-Contact: **support@opencad.org**
+Contact: **support@opencad.archi**
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/CariHQ/opencad.git"
   },
-  "homepage": "https://opencad.org",
+  "homepage": "https://opencad.archi",
   "bugs": {
     "url": "https://github.com/CariHQ/opencad/issues"
   },


### PR DESCRIPTION
## Summary

- `README.md`: browser app URL, docs/api/calendar links
- `SUPPORT.md`: docs, api, calendar links + support email
- `CONTRIBUTING.md`: calendar link
- `CODE_OF_CONDUCT.md`: conduct email
- `GOVERNANCE.md`: lead/conduct emails
- `SECURITY.md`: security email + well-known URL
- `package.json`: homepage field

All `opencad.org` → `opencad.archi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)