### PR TITLE
fix(app): persist active tool and category across refreshes

### DIFF
--- a/packages/app/src/components/ToolShelf.tsx
+++ b/packages/app/src/components/ToolShelf.tsx
@@ -64,7 +64,23 @@ const categories = [
 
 export function ToolShelf() {
   const { activeTool, setActiveTool } = useDocumentStore();
-  const [activeCategory, setActiveCategory] = React.useState('modify');
+  const [activeCategory, setActiveCategory] = React.useState<string>(() => {
+    try { return localStorage.getItem('opencad-activeCategory') ?? 'modify'; } catch { return 'modify'; }
+  });
+
+  // When activeTool changes (e.g. via keyboard shortcut), sync the category panel
+  React.useEffect(() => {
+    const toolDef = tools.find((t) => t.id === activeTool);
+    if (toolDef) {
+      setActiveCategory(toolDef.category);
+      try { localStorage.setItem('opencad-activeCategory', toolDef.category); } catch { /* ignore */ }
+    }
+  }, [activeTool]);
+
+  const handleSetCategory = (catId: string) => {
+    setActiveCategory(catId);
+    try { localStorage.setItem('opencad-activeCategory', catId); } catch { /* ignore */ }
+  };
 
   const filteredTools = tools.filter((t) => t.category === activeCategory);
 
@@ -77,7 +93,7 @@ export function ToolShelf() {
             <button
               key={cat.id}
               className={`category-btn ${activeCategory === cat.id ? 'active' : ''}`}
-              onClick={() => setActiveCategory(cat.id)}
+              onClick={() => handleSetCategory(cat.id)}
               title={cat.name}
             >
               <span className="tool-icon">

--- a/packages/app/src/stores/documentStore.ts
+++ b/packages/app/src/stores/documentStore.ts
@@ -51,7 +51,9 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   document: null,
   model: null,
   selectedIds: [],
-  activeTool: 'select',
+  activeTool: (() => {
+    try { return localStorage.getItem('opencad-activeTool') ?? 'select'; } catch { return 'select'; }
+  })(),
   isOnline: true,
   isSaving: false,
   lastSaved: null,
@@ -105,7 +107,10 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
 
   setSelectedIds: (ids) => set({ selectedIds: ids }),
 
-  setActiveTool: (tool) => set({ activeTool: tool }),
+  setActiveTool: (tool) => {
+    try { localStorage.setItem('opencad-activeTool', tool); } catch { /* ignore */ }
+    set({ activeTool: tool });
+  },
 
   setOnlineStatus: (online) => {
     const { model } = get();


### PR DESCRIPTION
## Problem

Active tool reset to `'select'` and active category reset to `'modify'` on every page refresh. Keyboard shortcuts changed the tool but didn't update the visible category panel.

## Fix

**`documentStore.ts`**:
- Init `activeTool` from `localStorage.getItem('opencad-activeTool')` (fallback `'select'`)
- `setActiveTool` writes the new value to localStorage before updating Zustand

**`ToolShelf.tsx`**:
- Init `activeCategory` from `localStorage.getItem('opencad-activeCategory')` (fallback `'modify'`)
- `handleSetCategory` writes to localStorage on manual category click
- `useEffect([activeTool])` syncs category panel when tool changes externally (keyboard shortcuts)

## Keys written to localStorage
| Key | Value |
|-----|-------|
| `opencad-activeTool` | e.g. `"rectangle"` |
| `opencad-activeCategory` | e.g. `"draw"` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)