### PR TITLE
feat(app): T-UI-001 split viewport

### DIFF
--- a/packages/app/src/AppLayout.tsx
+++ b/packages/app/src/AppLayout.tsx
@@ -6,6 +6,7 @@ import { LayersPanel } from './components/LayerPanel';
 import { PropertiesPanel } from './components/PropertiesPanel';
 import { StatusBar } from './components/StatusBar';
 import { Viewport } from './components/Viewport';
+import { SplitViewport } from './components/SplitViewport';
 import { AIChatPanel } from './components/AIChatPanel';
 import { LevelSelector } from './components/LevelSelector';
 import { ImportExportModal } from './components/ImportExportModal';
@@ -124,7 +125,7 @@ export function AppLayout() {
 
         <main className="app-main">
           <div className="viewport-wrapper">
-            <Viewport viewType={activeView} />
+            <SplitViewport viewType={activeView} />
           </div>
           <LevelSelector
             levels={doc?.levels || {}}

--- a/packages/app/src/components/SplitViewport.test.tsx
+++ b/packages/app/src/components/SplitViewport.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * T-UI-001: Multi-viewport split layout tests
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SplitViewport } from './SplitViewport';
+import { useDocumentStore } from '../stores/documentStore';
+
+vi.mock('../stores/documentStore');
+vi.mock('../hooks/useViewport', () => ({
+  useViewport: () => ({
+    canvasRef: { current: null },
+    containerRef: { current: null },
+    handleCanvasMouseDown: vi.fn(),
+    handleCanvasMouseMove: vi.fn(),
+    handleCanvasMouseUp: vi.fn(),
+    handleCanvasDoubleClick: vi.fn(),
+    activeTool: 'select',
+    drawingState: null,
+  }),
+}));
+vi.mock('../hooks/useThreeViewport', () => ({
+  useThreeViewport: () => ({
+    containerRef: { current: null },
+    setViewPreset: vi.fn(),
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    zoomToFit: vi.fn(),
+    sectionBox: false,
+    setSectionBox: vi.fn(),
+  }),
+}));
+
+const mockUseDocumentStore = vi.mocked(useDocumentStore);
+
+function makeStore() {
+  return {
+    document: null,
+    selectedIds: [],
+    setSelectedIds: vi.fn(),
+  };
+}
+
+describe('T-UI-001: SplitViewport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDocumentStore.mockReturnValue(makeStore() as ReturnType<typeof useDocumentStore>);
+  });
+
+  it('renders a toggle split button', () => {
+    render(<SplitViewport viewType="floor-plan" />);
+    expect(screen.getByTitle(/split view/i)).toBeInTheDocument();
+  });
+
+  it('renders single viewport by default', () => {
+    render(<SplitViewport viewType="floor-plan" />);
+    const panes = screen.queryAllByTestId('viewport-pane');
+    expect(panes).toHaveLength(1);
+  });
+
+  it('shows two panes when split mode is toggled on', () => {
+    render(<SplitViewport viewType="floor-plan" />);
+    fireEvent.click(screen.getByTitle(/split view/i));
+    const panes = screen.getAllByTestId('viewport-pane');
+    expect(panes).toHaveLength(2);
+  });
+
+  it('shows a divider handle in split mode', () => {
+    render(<SplitViewport viewType="floor-plan" />);
+    fireEvent.click(screen.getByTitle(/split view/i));
+    expect(screen.getByTestId('split-divider')).toBeInTheDocument();
+  });
+
+  it('left pane shows floor-plan label in split mode', () => {
+    render(<SplitViewport viewType="floor-plan" />);
+    fireEvent.click(screen.getByTitle(/split view/i));
+    expect(screen.getByText('Floor Plan')).toBeInTheDocument();
+  });
+
+  it('right pane shows 3D View label in split mode', () => {
+    render(<SplitViewport viewType="floor-plan" />);
+    fireEvent.click(screen.getByTitle(/split view/i));
+    expect(screen.getByText('3D View')).toBeInTheDocument();
+  });
+
+  it('returns to single pane when split mode is toggled off', () => {
+    render(<SplitViewport viewType="floor-plan" />);
+    fireEvent.click(screen.getByTitle(/split view/i)); // on
+    fireEvent.click(screen.getByTitle(/split view/i)); // off
+    const panes = screen.queryAllByTestId('viewport-pane');
+    expect(panes).toHaveLength(1);
+  });
+
+  it('passes viewType to single pane', () => {
+    render(<SplitViewport viewType="3d" />);
+    expect(screen.getByText('3D View')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/SplitViewport.tsx
+++ b/packages/app/src/components/SplitViewport.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useRef, useCallback } from 'react';
+import { Columns } from 'lucide-react';
+import { useViewport } from '../hooks/useViewport';
+import { useThreeViewport, ViewPreset } from '../hooks/useThreeViewport';
+
+interface ViewportPaneProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function ViewportPane({ label, children }: ViewportPaneProps) {
+  return (
+    <div className="viewport-pane" data-testid="viewport-pane" style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }}>
+      <div className="viewport-corner top-left" style={{ position: 'absolute', top: 8, left: 8, zIndex: 2, pointerEvents: 'none' }}>
+        <span>{label}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function FloorPlanPane() {
+  const { canvasRef, containerRef, handleCanvasMouseDown, handleCanvasMouseMove, handleCanvasMouseUp, handleCanvasDoubleClick } = useViewport();
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+      <canvas
+        ref={canvasRef}
+        className="viewport-canvas"
+        style={{ width: '100%', height: '100%' }}
+        onMouseDown={handleCanvasMouseDown}
+        onMouseMove={handleCanvasMouseMove}
+        onMouseUp={handleCanvasMouseUp}
+        onMouseLeave={handleCanvasMouseUp}
+        onDoubleClick={handleCanvasDoubleClick}
+      />
+    </div>
+  );
+}
+
+function ThreeDPane() {
+  const { containerRef, setViewPreset, zoomIn, zoomOut, zoomToFit, sectionBox, setSectionBox } = useThreeViewport();
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+  );
+}
+
+interface SplitViewportProps {
+  viewType?: 'floor-plan' | '3d' | 'section';
+}
+
+export function SplitViewport({ viewType = '3d' }: SplitViewportProps) {
+  const [isSplit, setIsSplit] = useState(false);
+  const [splitRatio, setSplitRatio] = useState(0.5);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+
+  const label = viewType === 'floor-plan' ? 'Floor Plan' : viewType === 'section' ? 'Section' : '3D View';
+
+  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+
+    const onMove = (ev: MouseEvent) => {
+      if (!isDragging.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const ratio = Math.max(0.2, Math.min(0.8, (ev.clientX - rect.left) / rect.width));
+      setSplitRatio(ratio);
+    };
+
+    const onUp = () => {
+      isDragging.current = false;
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="split-viewport-container" style={{ position: 'relative', width: '100%', height: '100%', display: 'flex' }}>
+      {/* Split toggle button */}
+      <button
+        className={`viewport-control-btn split-toggle ${isSplit ? 'active' : ''}`}
+        title="Split view"
+        onClick={() => setIsSplit((v) => !v)}
+        style={{ position: 'absolute', top: 8, right: 8, zIndex: 10 }}
+      >
+        <Columns size={14} />
+      </button>
+
+      {isSplit ? (
+        <>
+          <div style={{ width: `${splitRatio * 100}%`, height: '100%' }}>
+            <ViewportPane label="Floor Plan">
+              <FloorPlanPane />
+            </ViewportPane>
+          </div>
+
+          <div
+            data-testid="split-divider"
+            style={{ width: 4, height: '100%', cursor: 'col-resize', background: 'var(--border-color, #333)', flexShrink: 0 }}
+            onMouseDown={handleDividerMouseDown}
+          />
+
+          <div style={{ flex: 1, height: '100%' }}>
+            <ViewportPane label="3D View">
+              <ThreeDPane />
+            </ViewportPane>
+          </div>
+        </>
+      ) : (
+        <ViewportPane label={label}>
+          {viewType === '3d' ? <ThreeDPane /> : <FloorPlanPane />}
+        </ViewportPane>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `SplitViewport` component with toggle button (Columns icon) in top-right corner
- Split mode: Floor Plan (left) + 3D View (right) with draggable divider
- Divider resize clamped to 20%–80% of container width
- Single-pane fallback when split is off (respects `viewType` prop)
- Replaces static `<Viewport>` in `AppLayout`

## Test plan
- [x] 8 unit tests: toggle on/off, pane count, divider presence, labels, viewType passthrough
- [x] `pnpm typecheck` clean

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)