### PR TITLE
feat(app): T-BIM-003 door & window tool

### DIFF
--- a/packages/app/src/AppLayout.tsx
+++ b/packages/app/src/AppLayout.tsx
@@ -14,6 +14,7 @@ import { useDocumentStore } from './stores/documentStore';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import { WallToolPanel } from './components/WallToolPanel';
 import { SlabToolPanel } from './components/SlabToolPanel';
+import { DoorWindowPanel } from './components/DoorWindowPanel';
 import { useUndoRedo } from './hooks/useUndoRedo';
 import './styles/app.css';
 
@@ -206,7 +207,8 @@ export function AppLayout() {
 
         <aside className={`app-right-panel${rightVisible ? '' : ' panel-collapsed'}`}>
           {activeTool === 'wall' && <WallToolPanel />}
-          {activeTool === 'slab' && <SlabToolPanel />
+          {activeTool === 'slab' && <SlabToolPanel />}
+          {(activeTool === 'door' || activeTool === 'window') && <DoorWindowPanel />}
           <LayersPanel />
           <PropertiesPanel />
         </aside>

--- a/packages/app/src/components/DoorWindowPanel.test.tsx
+++ b/packages/app/src/components/DoorWindowPanel.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * T-BIM-003: Door & window tool panel tests
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DoorWindowPanel } from './DoorWindowPanel';
+import { useDocumentStore } from '../stores/documentStore';
+
+vi.mock('../stores/documentStore');
+
+const mockUseDocumentStore = vi.mocked(useDocumentStore);
+
+function makeStore(toolType: 'door' | 'window' = 'door', overrides = {}) {
+  return {
+    activeTool: toolType,
+    toolParams: {
+      door: { width: 900, height: 2100, swing: 90, frameType: 'standard' },
+      window: { width: 1200, height: 1200, sillHeight: 900, frameType: 'standard' },
+    },
+    setToolParam: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('T-BIM-003: DoorWindowPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Door mode', () => {
+    beforeEach(() => {
+      mockUseDocumentStore.mockReturnValue(makeStore('door') as ReturnType<typeof useDocumentStore>);
+    });
+
+    it('renders door panel title', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByText('Door')).toBeInTheDocument();
+    });
+
+    it('shows door width input', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByLabelText(/width/i)).toHaveValue(900);
+    });
+
+    it('shows door height input', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByLabelText(/height/i)).toHaveValue(2100);
+    });
+
+    it('shows swing angle input', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByLabelText(/swing/i)).toHaveValue(90);
+    });
+
+    it('shows frame type select', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByLabelText(/frame/i)).toBeInTheDocument();
+    });
+
+    it('calls setToolParam when door width changes', () => {
+      const store = makeStore('door');
+      mockUseDocumentStore.mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+      render(<DoorWindowPanel />);
+      fireEvent.change(screen.getByLabelText(/width/i), { target: { value: '1000' } });
+      expect(store.setToolParam).toHaveBeenCalledWith('door', 'width', 1000);
+    });
+  });
+
+  describe('Window mode', () => {
+    beforeEach(() => {
+      mockUseDocumentStore.mockReturnValue(makeStore('window') as ReturnType<typeof useDocumentStore>);
+    });
+
+    it('renders window panel title', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByText('Window')).toBeInTheDocument();
+    });
+
+    it('shows sill height input', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByLabelText(/sill/i)).toHaveValue(900);
+    });
+
+    it('calls setToolParam when sill height changes', () => {
+      const store = makeStore('window');
+      mockUseDocumentStore.mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+      render(<DoorWindowPanel />);
+      fireEvent.change(screen.getByLabelText(/sill/i), { target: { value: '1000' } });
+      expect(store.setToolParam).toHaveBeenCalledWith('window', 'sillHeight', 1000);
+    });
+
+    it('shows placement hint mentioning wall', () => {
+      render(<DoorWindowPanel />);
+      expect(screen.getByText(/wall/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/app/src/components/DoorWindowPanel.tsx
+++ b/packages/app/src/components/DoorWindowPanel.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { useDocumentStore } from '../stores/documentStore';
+
+const FRAME_TYPES = ['standard', 'aluminum', 'timber', 'steel'] as const;
+
+export function DoorWindowPanel() {
+  const { activeTool, toolParams, setToolParam } = useDocumentStore();
+  const isDoor = activeTool === 'door';
+  const toolKey = isDoor ? 'door' : 'window';
+
+  const params = (toolParams?.[toolKey] ?? {}) as Record<string, unknown>;
+
+  if (isDoor) {
+    return (
+      <div className="placement-panel">
+        <div className="placement-header">
+          <span className="placement-title">Door</span>
+        </div>
+        <div className="placement-params">
+          <div className="placement-param">
+            <label htmlFor="door-width">Width (mm)</label>
+            <input
+              id="door-width"
+              type="number"
+              value={(params['width'] as number) ?? 900}
+              min={300} max={3000} step={50}
+              onChange={(e) => setToolParam('door', 'width', Number(e.target.value))}
+            />
+          </div>
+          <div className="placement-param">
+            <label htmlFor="door-height">Height (mm)</label>
+            <input
+              id="door-height"
+              type="number"
+              value={(params['height'] as number) ?? 2100}
+              min={1800} max={4000} step={100}
+              onChange={(e) => setToolParam('door', 'height', Number(e.target.value))}
+            />
+          </div>
+          <div className="placement-param">
+            <label htmlFor="door-swing">Swing (°)</label>
+            <input
+              id="door-swing"
+              type="number"
+              value={(params['swing'] as number) ?? 90}
+              min={0} max={180} step={15}
+              onChange={(e) => setToolParam('door', 'swing', Number(e.target.value))}
+            />
+          </div>
+          <div className="placement-param">
+            <label htmlFor="door-frame">Frame Type</label>
+            <select
+              id="door-frame"
+              value={(params['frameType'] as string) ?? 'standard'}
+              onChange={(e) => setToolParam('door', 'frameType', e.target.value)}
+            >
+              {FRAME_TYPES.map((f) => (
+                <option key={f} value={f}>{f.charAt(0).toUpperCase() + f.slice(1)}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="placement-hint">Click on a wall to place door</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="placement-panel">
+      <div className="placement-header">
+        <span className="placement-title">Window</span>
+      </div>
+      <div className="placement-params">
+        <div className="placement-param">
+          <label htmlFor="win-width">Width (mm)</label>
+          <input
+            id="win-width"
+            type="number"
+            value={(params['width'] as number) ?? 1200}
+            min={300} max={3000} step={50}
+            onChange={(e) => setToolParam('window', 'width', Number(e.target.value))}
+          />
+        </div>
+        <div className="placement-param">
+          <label htmlFor="win-height">Height (mm)</label>
+          <input
+            id="win-height"
+            type="number"
+            value={(params['height'] as number) ?? 1200}
+            min={300} max={3000} step={100}
+            onChange={(e) => setToolParam('window', 'height', Number(e.target.value))}
+          />
+        </div>
+        <div className="placement-param">
+          <label htmlFor="win-sill">Sill Height (mm)</label>
+          <input
+            id="win-sill"
+            type="number"
+            value={(params['sillHeight'] as number) ?? 900}
+            min={0} max={2000} step={100}
+            onChange={(e) => setToolParam('window', 'sillHeight', Number(e.target.value))}
+          />
+        </div>
+        <div className="placement-param">
+          <label htmlFor="win-frame">Frame Type</label>
+          <select
+            id="win-frame"
+            value={(params['frameType'] as string) ?? 'standard'}
+            onChange={(e) => setToolParam('window', 'frameType', e.target.value)}
+          >
+            {FRAME_TYPES.map((f) => (
+              <option key={f} value={f}>{f.charAt(0).toUpperCase() + f.slice(1)}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="placement-hint">Click on a wall to place window</div>
+    </div>
+  );
+}

--- a/packages/app/src/hooks/useViewport.ts
+++ b/packages/app/src/hooks/useViewport.ts
@@ -257,7 +257,38 @@ export function useViewport() {
       });
       getStoreActions().pushHistory(`Add ${tool}`);
     }
-  }, [doc, addElement]);
+
+    if (tool === 'door' || tool === 'window') {
+      // Find nearest wall element to host this opening
+      const walls = Object.values(doc.elements).filter((el) => el.type === 'wall');
+      let hostWallId = '';
+      let minD = Infinity;
+      for (const wall of walls) {
+        const bb = wall.boundingBox;
+        const cx = (bb.min.x + bb.max.x) / 2;
+        const cy = (bb.min.y + bb.max.y) / 2;
+        const d = dist(start, { x: cx, y: cy });
+        if (d < minD) { minD = d; hostWallId = wall.id; }
+      }
+      const tp = (toolParams?.[tool] ?? {}) as Record<string, unknown>;
+      addElement({
+        type: tool, layerId,
+        properties: {
+          Name: { type: 'string', value: tool === 'door' ? 'Door' : 'Window' },
+          X: { type: 'number', value: start.x },
+          Y: { type: 'number', value: start.y },
+          Width: { type: 'number', value: tp['width'] ?? (tool === 'door' ? 900 : 1200) },
+          Height: { type: 'number', value: tp['height'] ?? (tool === 'door' ? 2100 : 1200) },
+          ...(tool === 'door'
+            ? { Swing: { type: 'number', value: tp['swing'] ?? 90 } }
+            : { SillHeight: { type: 'number', value: tp['sillHeight'] ?? 900 } }),
+          FrameType: { type: 'string', value: tp['frameType'] ?? 'standard' },
+          HostWallId: { type: 'reference', value: hostWallId },
+        },
+      });
+      getStoreActions().pushHistory(`Add ${tool}`);
+    }
+  }, [doc, addElement, toolParams]);
 
   // ─── Canvas draw loop ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `DoorWindowPanel` (replaces standalone `PlacementPanel`): door params (width/height/swing/frameType) and window params (width/height/sillHeight/frameType), both driven by `toolParams` in the store
- Shown in right panel when door/window tool is active
- `useViewport`: single-click places door/window at click point; nearest wall is found and stored as `HostWallId` reference on the element
- `toolParams.door` and `toolParams.window` defaults added to `documentStore`

## Test plan
- [x] 10 unit tests: door panel (width/height/swing/frame, onChange callback), window panel (sill height, onChange, placement hint)
- [x] `pnpm typecheck` clean

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)