### PR TITLE
feat(app): T-UI-004 navigator search, layers tree, visibility/lock

### DIFF
--- a/packages/app/src/AppLayout.test.tsx
+++ b/packages/app/src/AppLayout.test.tsx
@@ -64,7 +64,11 @@ describe('T-UI-006: AppLayout', () => {
 
   it('renders Layers panel', () => {
     render(<AppLayout />);
-    expect(screen.getByText('Layers')).toBeInTheDocument();
+    // 'Layers' appears in both the Navigator tree and the LayersPanel — use panel-title class
+    const layerPanelTitle = document.querySelector('.panel-title');
+    expect(layerPanelTitle).not.toBeNull();
+    const layersTitles = screen.getAllByText('Layers');
+    expect(layersTitles.length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders StatusBar', () => {

--- a/packages/app/src/components/Navigator.test.tsx
+++ b/packages/app/src/components/Navigator.test.tsx
@@ -1,10 +1,10 @@
 /**
  * T-UI-004: Navigator component tests
  *
- * Verifies: sections render, levels display, elements list, selection works.
+ * Verifies: hierarchy, expand/collapse, selection, visibility toggle, lock toggle, search.
  */
 import '@testing-library/jest-dom/vitest';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Navigator } from './Navigator';
 import { useDocumentStore } from '../stores/documentStore';
@@ -20,6 +20,11 @@ describe('T-UI-004: Navigator', () => {
     expect(screen.getByText('Navigator')).toBeInTheDocument();
   });
 
+  it('shows search input', () => {
+    render(<Navigator />);
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+  });
+
   it('shows Views section expanded by default', () => {
     render(<Navigator />);
     expect(screen.getByText('Floor Plan')).toBeInTheDocument();
@@ -31,9 +36,21 @@ describe('T-UI-004: Navigator', () => {
     expect(screen.getByText('Level 1')).toBeInTheDocument();
   });
 
-  it('shows element count badge', () => {
+  it('shows Layers section', () => {
     render(<Navigator />);
-    // Elements section header has a count
+    expect(screen.getByText('Layers')).toBeInTheDocument();
+  });
+
+  it('shows layer names in layers section', () => {
+    render(<Navigator />);
+    // Default document has at least one layer
+    const doc = useDocumentStore.getState().document!;
+    const firstLayer = Object.values(doc.layers)[0];
+    expect(screen.getByText(firstLayer.name)).toBeInTheDocument();
+  });
+
+  it('shows element count badge for elements', () => {
+    render(<Navigator />);
     const elements = screen.getAllByText('Elements');
     expect(elements.length).toBeGreaterThan(0);
   });
@@ -45,12 +62,109 @@ describe('T-UI-004: Navigator', () => {
     expect(screen.queryByText('Floor Plan')).not.toBeInTheDocument();
   });
 
+  it('collapses Layers section on click', () => {
+    render(<Navigator />);
+    const doc = useDocumentStore.getState().document!;
+    const firstLayer = Object.values(doc.layers)[0];
+    const layersFolder = screen.getByText('Layers').closest('.nav-item')!;
+    fireEvent.click(layersFolder);
+    expect(screen.queryByText(firstLayer.name)).not.toBeInTheDocument();
+  });
+
   it('selects a level on click', () => {
     render(<Navigator />);
     const levelItem = screen.getByText('Level 1').closest('.nav-item')!;
     fireEvent.click(levelItem);
-
     const state = useDocumentStore.getState();
     expect(state.selectedIds.length).toBe(1);
+  });
+
+  it('shows eye (visibility) button on each layer', () => {
+    render(<Navigator />);
+    // There should be at least one eye button
+    const eyeBtns = screen.getAllByTitle(/visibility/i);
+    expect(eyeBtns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows lock button on each layer', () => {
+    render(<Navigator />);
+    const lockBtns = screen.getAllByTitle(/lock/i);
+    expect(lockBtns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('clicking eye button calls updateLayer with toggled visible', () => {
+    const updateLayer = vi.spyOn(useDocumentStore.getState(), 'updateLayer');
+    render(<Navigator />);
+    const eyeBtns = screen.getAllByTitle(/visibility/i);
+    fireEvent.click(eyeBtns[0]);
+    expect(updateLayer).toHaveBeenCalled();
+    const [, updates] = updateLayer.mock.calls[0];
+    expect(updates).toHaveProperty('visible');
+  });
+
+  it('clicking lock button calls updateLayer with toggled locked', () => {
+    const updateLayer = vi.spyOn(useDocumentStore.getState(), 'updateLayer');
+    render(<Navigator />);
+    const lockBtns = screen.getAllByTitle(/lock/i);
+    fireEvent.click(lockBtns[0]);
+    expect(updateLayer).toHaveBeenCalled();
+    const [, updates] = updateLayer.mock.calls[0];
+    expect(updates).toHaveProperty('locked');
+  });
+
+  it('search input filters elements by type', () => {
+    // Add an element so we have something to filter
+    const state = useDocumentStore.getState();
+    const layerId = Object.keys(state.document!.layers)[0];
+    state.addElement({ type: 'wall', layerId, properties: {} });
+
+    render(<Navigator />);
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(searchInput, { target: { value: 'wall' } });
+    // At least one element with 'wall' in name should remain
+    const wallItems = screen.queryAllByText(/wall/i);
+    expect(wallItems.length).toBeGreaterThan(0);
+  });
+
+  it('search hides non-matching elements', () => {
+    const state = useDocumentStore.getState();
+    const layerId = Object.keys(state.document!.layers)[0];
+    state.addElement({ type: 'wall', layerId, properties: {} });
+    state.addElement({ type: 'door', layerId, properties: {} });
+
+    render(<Navigator />);
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(searchInput, { target: { value: 'wall' } });
+    // door-named items in .item-name spans should not appear
+    const allNames = screen.queryAllByText(/^door [a-z0-9]+$/i);
+    expect(allNames.length).toBe(0);
+  });
+
+  it('element count shows correct number per layer branch', () => {
+    // Start fresh
+    localStorage.clear();
+    useDocumentStore.getState().initProject('test-project', 'test-user');
+
+    const state = useDocumentStore.getState();
+    const layerId = Object.keys(state.document!.layers)[0];
+    state.addElement({ type: 'wall', layerId, properties: {} });
+    state.addElement({ type: 'wall', layerId, properties: {} });
+
+    const { container } = render(<Navigator />);
+    const countBadges = container.querySelectorAll('.item-count');
+    const countValues = Array.from(countBadges).map((el) => el.textContent);
+    expect(countValues).toContain('2');
+  });
+
+  it('clicking an element in tree selects it in the store', () => {
+    const state = useDocumentStore.getState();
+    const layerId = Object.keys(state.document!.layers)[0];
+    const elemId = state.addElement({ type: 'wall', layerId, properties: {} });
+
+    render(<Navigator />);
+    // Element should appear with its short id or 'wall ...'
+    const elemItems = screen.getAllByText(new RegExp(`wall ${elemId.slice(0, 6)}`, 'i'));
+    fireEvent.click(elemItems[0]);
+    expect(useDocumentStore.getState().selectedIds).toContain(elemId);
   });
 });

--- a/packages/app/src/components/Navigator.tsx
+++ b/packages/app/src/components/Navigator.tsx
@@ -12,23 +12,42 @@ import {
   DoorOpen,
   AppWindow,
   Hash,
+  Eye,
+  EyeOff,
+  Lock,
+  Unlock,
 } from 'lucide-react';
 import { useDocumentStore } from '../stores/documentStore';
 
 export function Navigator() {
-  const { document: doc, selectedIds, setSelectedIds } = useDocumentStore();
+  const { document: doc, selectedIds, setSelectedIds, updateLayer } = useDocumentStore();
   const [expanded, setExpanded] = useState<Record<string, boolean>>({
     views: true,
     levels: true,
+    layers: true,
     elements: true,
   });
+  const [search, setSearch] = useState('');
 
   const toggleExpanded = (id: string) => {
     setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
   };
 
   const levels = doc?.levels ? Object.values(doc.levels) : [];
+  const layers = doc?.layers ? Object.values(doc.layers) : [];
   const elements = doc?.elements ? Object.values(doc.elements) : [];
+
+  const filteredElements = search
+    ? elements.filter((el) => {
+        const q = search.toLowerCase();
+        const name = (el.properties?.Name?.value as string | undefined) ?? '';
+        return (
+          el.type.toLowerCase().includes(q) ||
+          el.id.toLowerCase().includes(q) ||
+          name.toLowerCase().includes(q)
+        );
+      })
+    : elements;
 
   const getElementIcon = (type: string) => {
     switch (type) {
@@ -51,7 +70,17 @@ export function Navigator() {
         <span className="navigator-title">Navigator</span>
       </div>
 
+      <div className="navigator-search">
+        <input
+          className="navigator-search-input"
+          placeholder="Search elements…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+
       <div className="navigator-content">
+        {/* Views */}
         <div className="nav-section">
           <div className="nav-item folder" onClick={() => toggleExpanded('views')}>
             <span className={`expand-icon ${expanded.views ? 'expanded' : ''}`}>
@@ -92,6 +121,7 @@ export function Navigator() {
           )}
         </div>
 
+        {/* Levels */}
         <div className="nav-section">
           <div className="nav-item folder" onClick={() => toggleExpanded('levels')}>
             <span className={`expand-icon ${expanded.levels ? 'expanded' : ''}`}>
@@ -124,6 +154,75 @@ export function Navigator() {
           )}
         </div>
 
+        {/* Layers */}
+        <div className="nav-section">
+          <div className="nav-item folder" onClick={() => toggleExpanded('layers')}>
+            <span className={`expand-icon ${expanded.layers ? 'expanded' : ''}`}>
+              <ChevronRight size={12} />
+            </span>
+            <span className="item-icon">
+              <Layers size={14} />
+            </span>
+            <span className="item-name">Layers</span>
+            <span className="item-count">{layers.length}</span>
+          </div>
+          {expanded.layers && (
+            <div className="nav-children">
+              {layers
+                .sort((a, b) => a.order - b.order)
+                .map((layer) => {
+                  const layerElements = filteredElements.filter((e) => e.layerId === layer.id);
+                  return (
+                    <React.Fragment key={layer.id}>
+                      <div className="nav-item layer">
+                        <span
+                          className="layer-color-dot"
+                          style={{ background: layer.color }}
+                        />
+                        <span className="item-name">{layer.name}</span>
+                        <span className="item-count">{layerElements.length}</span>
+                        <button
+                          className="nav-icon-btn"
+                          title={layer.visible ? 'Hide layer visibility' : 'Show layer visibility'}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            updateLayer(layer.id, { visible: !layer.visible });
+                          }}
+                        >
+                          {layer.visible ? <Eye size={12} /> : <EyeOff size={12} />}
+                        </button>
+                        <button
+                          className="nav-icon-btn"
+                          title={layer.locked ? 'Unlock layer' : 'Lock layer'}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            updateLayer(layer.id, { locked: !layer.locked });
+                          }}
+                        >
+                          {layer.locked ? <Lock size={12} /> : <Unlock size={12} />}
+                        </button>
+                      </div>
+                      {layerElements.slice(0, 50).map((element) => (
+                        <div
+                          key={element.id}
+                          className={`nav-item element nav-child-indent ${selectedIds.includes(element.id) ? 'selected' : ''}`}
+                          onClick={() => setSelectedIds([element.id])}
+                        >
+                          <span className="item-icon">{getElementIcon(element.type)}</span>
+                          <span className="item-name">
+                            {(element.properties?.Name?.value as string | undefined) ||
+                              `${element.type} ${element.id.slice(0, 6)}`}
+                          </span>
+                        </div>
+                      ))}
+                    </React.Fragment>
+                  );
+                })}
+            </div>
+          )}
+        </div>
+
+        {/* Elements (flat list, respects search) */}
         <div className="nav-section">
           <div className="nav-item folder" onClick={() => toggleExpanded('elements')}>
             <span className={`expand-icon ${expanded.elements ? 'expanded' : ''}`}>
@@ -133,11 +232,11 @@ export function Navigator() {
               <BrickWall size={14} />
             </span>
             <span className="item-name">Elements</span>
-            <span className="item-count">{elements.length}</span>
+            <span className="item-count">{filteredElements.length}</span>
           </div>
           {expanded.elements && (
             <div className="nav-children">
-              {elements.slice(0, 50).map((element) => (
+              {filteredElements.slice(0, 50).map((element) => (
                 <div
                   key={element.id}
                   className={`nav-item element ${selectedIds.includes(element.id) ? 'selected' : ''}`}
@@ -145,13 +244,14 @@ export function Navigator() {
                 >
                   <span className="item-icon">{getElementIcon(element.type)}</span>
                   <span className="item-name">
-                    {element.properties?.Name?.value || `${element.type} ${element.id.slice(0, 6)}`}
+                    {(element.properties?.Name?.value as string | undefined) ||
+                      `${element.type} ${element.id.slice(0, 6)}`}
                   </span>
                 </div>
               ))}
-              {elements.length > 50 && (
+              {filteredElements.length > 50 && (
                 <div className="nav-item more">
-                  <span className="item-name">+{elements.length - 50} more...</span>
+                  <span className="item-name">+{filteredElements.length - 50} more…</span>
                 </div>
               )}
             </div>

--- a/packages/app/src/styles/app.css
+++ b/packages/app/src/styles/app.css
@@ -263,6 +263,49 @@ body {
   padding-left: 16px;
 }
 
+.nav-child-indent {
+  padding-left: 32px !important;
+}
+
+.navigator-search {
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.navigator-search-input {
+  width: 100%;
+  padding: 5px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.nav-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.nav-item:hover .nav-icon-btn {
+  opacity: 1;
+}
+
+.layer-color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-right: 4px;
+}
+
 /* Tool Shelf */
 .app-toolshelf-container {
   width: 52px;


### PR DESCRIPTION
## Summary

- Added **Layers section** to Navigator tree showing layers → elements hierarchy
- **Eye icon** per layer to toggle `visible` (calls `updateLayer`)
- **Lock icon** per layer to toggle `locked` (calls `updateLayer`)
- **Search input** at top of Navigator filters elements by type, ID, or name (case-insensitive)
- **Element count badges** per layer branch and Elements section
- Fixed AppLayout test that used `getByText('Layers')` — now "Layers" appears in both Navigator and LayersPanel

## Test plan

- [x] 17 Navigator unit tests (hierarchy, expand/collapse, selection, search, eye/lock toggles, count badges)
- [x] 107 total tests passing
- [x] TypeScript clean

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)