### PR TITLE
feat(app): T-BIM-007 section box — clip 3D model for section/elevation views

### DIFF
--- a/packages/app/src/components/ThreeViewportInner.tsx
+++ b/packages/app/src/components/ThreeViewportInner.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { useThreeViewport, type ViewPreset } from '../hooks/useThreeViewport';
 import { ZoomIn, ZoomOut, Maximize, Box } from 'lucide-react';
+import { SectionBoxPanel } from './SectionBoxPanel';
 
 interface ThreeViewportInnerProps {
   onViewChange?: (preset: ViewPreset) => void;
@@ -21,6 +22,11 @@ export function ThreeViewportInner({ onViewChange }: ThreeViewportInnerProps) {
     zoomToFit,
     sectionBox,
     setSectionBox,
+    sectionPosition,
+    setSectionPosition,
+    sectionDirection,
+    setSectionDirection,
+    saveSectionView,
   } = useThreeViewport();
 
   const handleViewChange = (preset: ViewPreset) => {
@@ -63,6 +69,19 @@ export function ThreeViewportInner({ onViewChange }: ThreeViewportInnerProps) {
           <Box size={14} />
         </button>
       </div>
+      {sectionBox && (
+        <div className="section-box-overlay">
+          <SectionBoxPanel
+            enabled={sectionBox}
+            position={sectionPosition}
+            direction={sectionDirection}
+            onToggle={() => setSectionBox(!sectionBox)}
+            onPositionChange={setSectionPosition}
+            onDirectionChange={setSectionDirection}
+            onSaveView={saveSectionView}
+          />
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Implements `SectionBoxPanel` component with enable toggle, direction select (X/Y/Z), position slider, and Save View button
- Extends `useThreeViewport` with Three.js clipping planes (`renderer.localClippingEnabled = true`), `sectionDirection` state, and `saveSectionView` callback
- Wires `SectionBoxPanel` into `ThreeViewportInner` as an overlay when the section box is active

## Test plan

- [ ] `SectionBoxPanel.test.tsx` — 14 tests covering all interactive controls
- [ ] All 110 app tests passing
- [ ] TypeScript typecheck clean

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)