### PR TITLE
feat(app): T-UI-003 properties panel — inline editing with multi-select

### DIFF
--- a/packages/app/src/components/PropertiesPanel.test.tsx
+++ b/packages/app/src/components/PropertiesPanel.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { PropertiesPanel } from './PropertiesPanel';
+import { useDocumentStore } from '../stores/documentStore';
+
+vi.mock('../stores/documentStore');
+
+const baseElement = {
+  id: 'el-1',
+  type: 'wall' as const,
+  layerId: 'layer-1',
+  levelId: null,
+  visible: true,
+  locked: false,
+  properties: {
+    height: { type: 'number' as const, value: 3000, unit: 'mm' },
+    thickness: { type: 'number' as const, value: 200, unit: 'mm' },
+    material: { type: 'string' as const, value: 'Concrete' },
+  },
+  propertySets: [],
+  geometry: { type: 'brep' as const, data: null },
+  transform: {
+    translation: { x: 0, y: 0, z: 0 },
+    rotation: { x: 0, y: 0, z: 0, w: 1 },
+    scale: { x: 1, y: 1, z: 1 },
+  },
+  boundingBox: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+  metadata: { id: 'el-1', createdBy: 'u1', createdAt: 0, updatedAt: 0, version: {} },
+};
+
+const makeStore = (overrides = {}) => ({
+  document: {
+    id: 'doc-1',
+    elements: { 'el-1': baseElement },
+    layers: {},
+    levels: {},
+    versions: [],
+    vectorClock: {},
+  },
+  selectedIds: [],
+  updateElement: vi.fn(),
+  pushHistory: vi.fn(),
+  setSelectedIds: vi.fn(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useDocumentStore).mockReturnValue(makeStore() as ReturnType<typeof useDocumentStore>);
+});
+
+describe('T-UI-003: PropertiesPanel', () => {
+  it('shows empty state when no element selected', () => {
+    render(<PropertiesPanel />);
+    expect(screen.getByText(/select an element/i)).toBeInTheDocument();
+  });
+
+  it('shows element type when element is selected', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({ selectedIds: ['el-1'] }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    expect(screen.getByText('wall')).toBeInTheDocument();
+  });
+
+  it('renders property rows for each element property', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({ selectedIds: ['el-1'] }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    expect(screen.getByText('height')).toBeInTheDocument();
+    expect(screen.getByText('thickness')).toBeInTheDocument();
+    expect(screen.getByText('material')).toBeInTheDocument();
+  });
+
+  it('shows number property value in input', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({ selectedIds: ['el-1'] }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    const heightInput = screen.getByDisplayValue('3000');
+    expect(heightInput).toBeInTheDocument();
+  });
+
+  it('shows string property value in input', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({ selectedIds: ['el-1'] }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    expect(screen.getByDisplayValue('Concrete')).toBeInTheDocument();
+  });
+
+  it('calls updateElement with new number value on blur', () => {
+    const store = makeStore({ selectedIds: ['el-1'] });
+    vi.mocked(useDocumentStore).mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+    render(<PropertiesPanel />);
+    const heightInput = screen.getByDisplayValue('3000');
+    fireEvent.change(heightInput, { target: { value: '3500' } });
+    fireEvent.blur(heightInput);
+    expect(store.updateElement).toHaveBeenCalledWith('el-1', expect.objectContaining({
+      properties: expect.objectContaining({
+        height: expect.objectContaining({ value: 3500 }),
+      }),
+    }));
+  });
+
+  it('calls updateElement with new string value on blur', () => {
+    const store = makeStore({ selectedIds: ['el-1'] });
+    vi.mocked(useDocumentStore).mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+    render(<PropertiesPanel />);
+    const matInput = screen.getByDisplayValue('Concrete');
+    fireEvent.change(matInput, { target: { value: 'Steel' } });
+    fireEvent.blur(matInput);
+    expect(store.updateElement).toHaveBeenCalledWith('el-1', expect.objectContaining({
+      properties: expect.objectContaining({
+        material: expect.objectContaining({ value: 'Steel' }),
+      }),
+    }));
+  });
+
+  it('calls pushHistory after updating element', () => {
+    const store = makeStore({ selectedIds: ['el-1'] });
+    vi.mocked(useDocumentStore).mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+    render(<PropertiesPanel />);
+    const heightInput = screen.getByDisplayValue('3000');
+    fireEvent.change(heightInput, { target: { value: '4000' } });
+    fireEvent.blur(heightInput);
+    expect(store.pushHistory).toHaveBeenCalled();
+  });
+
+  it('shows unit label next to number property', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({ selectedIds: ['el-1'] }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    const unitLabels = screen.getAllByText('mm');
+    expect(unitLabels.length).toBeGreaterThan(0);
+  });
+
+  it('shows Add Property button', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({ selectedIds: ['el-1'] }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    expect(screen.getByRole('button', { name: /add property/i })).toBeInTheDocument();
+  });
+
+  it('adds a new custom property when Add Property is clicked', () => {
+    const store = makeStore({ selectedIds: ['el-1'] });
+    vi.mocked(useDocumentStore).mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+    render(<PropertiesPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /add property/i }));
+    expect(store.updateElement).toHaveBeenCalledWith('el-1', expect.objectContaining({
+      properties: expect.objectContaining({
+        'Custom Property': expect.any(Object),
+      }),
+    }));
+  });
+
+  it('shows multi-select summary when multiple elements selected', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({
+        selectedIds: ['el-1', 'el-2'],
+        document: {
+          id: 'doc-1',
+          elements: {
+            'el-1': baseElement,
+            'el-2': { ...baseElement, id: 'el-2' },
+          },
+          layers: {},
+          levels: {},
+          versions: [],
+          vectorClock: {},
+        },
+      }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    expect(screen.getByText(/2 elements selected/i)).toBeInTheDocument();
+  });
+
+  it('shows shared properties in multi-select mode', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({
+        selectedIds: ['el-1', 'el-2'],
+        document: {
+          id: 'doc-1',
+          elements: {
+            'el-1': baseElement,
+            'el-2': { ...baseElement, id: 'el-2' },
+          },
+          layers: {},
+          levels: {},
+          versions: [],
+          vectorClock: {},
+        },
+      }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    expect(screen.getByText('height')).toBeInTheDocument();
+    expect(screen.getByText('material')).toBeInTheDocument();
+  });
+
+  it('calls updateElement for all selected elements in multi-select', () => {
+    const store = makeStore({
+      selectedIds: ['el-1', 'el-2'],
+      document: {
+        id: 'doc-1',
+        elements: {
+          'el-1': baseElement,
+          'el-2': { ...baseElement, id: 'el-2' },
+        },
+        layers: {},
+        levels: {},
+        versions: [],
+        vectorClock: {},
+      },
+    });
+    vi.mocked(useDocumentStore).mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+    render(<PropertiesPanel />);
+    const heightInput = screen.getByDisplayValue('3000');
+    fireEvent.change(heightInput, { target: { value: '4000' } });
+    fireEvent.blur(heightInput);
+    expect(store.updateElement).toHaveBeenCalledWith('el-1', expect.anything());
+    expect(store.updateElement).toHaveBeenCalledWith('el-2', expect.anything());
+  });
+
+  it('shows location X, Y, Z inputs', () => {
+    vi.mocked(useDocumentStore).mockReturnValue(
+      makeStore({ selectedIds: ['el-1'] }) as ReturnType<typeof useDocumentStore>
+    );
+    render(<PropertiesPanel />);
+    expect(screen.getByLabelText(/^X$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Y$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Z$/i)).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/PropertiesPanel.tsx
+++ b/packages/app/src/components/PropertiesPanel.tsx
@@ -1,7 +1,10 @@
+import React, { useState } from 'react';
 import { useDocumentStore } from '../stores/documentStore';
+import type { PropertyValue } from '@opencad/document';
 
 export function PropertiesPanel() {
-  const { document: doc, selectedIds } = useDocumentStore();
+  const { document: doc, selectedIds, updateElement, pushHistory } = useDocumentStore();
+  const [localValues, setLocalValues] = useState<Record<string, Record<string, string>>>({});
 
   if (!doc) return null;
 
@@ -20,78 +23,153 @@ export function PropertiesPanel() {
     );
   }
 
-  const selectedElement = doc.elements[selectedIds[0]];
-  if (!selectedElement) return null;
+  const isMulti = selectedIds.length > 1;
+  const selectedElements = selectedIds
+    .map((id) => doc.elements[id])
+    .filter(Boolean);
+
+  if (selectedElements.length === 0) return null;
+
+  const primaryElement = selectedElements[0]!;
+
+  // For multi-select: only show properties shared by all selected elements
+  const sharedProperties = isMulti
+    ? Object.fromEntries(
+        Object.entries(primaryElement.properties).filter(([key]) =>
+          selectedElements.every((el) => key in el.properties)
+        )
+      )
+    : primaryElement.properties;
+
+  const handlePropertyChange = (propKey: string, rawValue: string) => {
+    setLocalValues((prev) => ({
+      ...prev,
+      [primaryElement.id]: { ...(prev[primaryElement.id] ?? {}), [propKey]: rawValue },
+    }));
+  };
+
+  const handlePropertyBlur = (propKey: string, prop: PropertyValue, rawValue: string) => {
+    const parsed: PropertyValue =
+      prop.type === 'number'
+        ? { ...prop, value: parseFloat(rawValue) || 0 }
+        : { ...prop, value: rawValue };
+
+    for (const el of selectedElements) {
+      updateElement(el.id, {
+        properties: { ...el.properties, [propKey]: parsed },
+      });
+    }
+    pushHistory(`Edit ${propKey}`);
+
+    // Clear local override
+    setLocalValues((prev) => {
+      const next = { ...prev };
+      if (next[primaryElement.id]) {
+        const copy = { ...next[primaryElement.id] };
+        delete copy[propKey];
+        next[primaryElement.id] = copy;
+      }
+      return next;
+    });
+  };
+
+  const handleLocationBlur = (axis: 'x' | 'y' | 'z', rawValue: string) => {
+    const num = parseFloat(rawValue) || 0;
+    for (const el of selectedElements) {
+      updateElement(el.id, {
+        transform: {
+          ...el.transform,
+          translation: { ...el.transform.translation, [axis]: num },
+        },
+      });
+    }
+    pushHistory(`Move ${axis.toUpperCase()}`);
+  };
+
+  const handleAddProperty = () => {
+    const newKey = 'Custom Property';
+    const newProp: PropertyValue = { type: 'string', value: '' };
+    for (const el of selectedElements) {
+      updateElement(el.id, {
+        properties: { ...el.properties, [newKey]: newProp },
+      });
+    }
+    pushHistory('Add property');
+  };
+
+  const getDisplayValue = (propKey: string, prop: PropertyValue): string => {
+    const local = localValues[primaryElement.id]?.[propKey];
+    if (local !== undefined) return local;
+    return String(prop.value);
+  };
+
+  const { x, y, z } = primaryElement.transform.translation;
 
   return (
     <div className="properties-panel">
       <div className="panel-header">
         <span className="panel-title">Properties</span>
-        <div className="panel-actions">
-          <button className="panel-action-btn" title="More">
-            ⋮
-          </button>
-        </div>
       </div>
       <div className="properties-content">
+        {isMulti && (
+          <div className="properties-multi-summary">{selectedIds.length} elements selected</div>
+        )}
+
         <div className="property-group">
           <div className="property-group-title">General</div>
           <div className="property-row">
             <span className="property-label">Type</span>
             <div className="property-value">
-              <input type="text" className="property-input" value={selectedElement.type} disabled />
+              <span>{primaryElement.type}</span>
             </div>
           </div>
         </div>
 
-        <div className="property-group">
-          <div className="property-group-title">Location</div>
-          <div className="property-row">
-            <span className="property-label">X</span>
-            <div className="property-value">
-              <input
-                type="number"
-                className="property-input"
-                value={selectedElement.transform.translation.x.toFixed(1)}
-              />
-            </div>
+        {!isMulti && (
+          <div className="property-group">
+            <div className="property-group-title">Location</div>
+            {(['x', 'y', 'z'] as const).map((axis) => (
+              <div key={axis} className="property-row">
+                <label htmlFor={`loc-${axis}`} className="property-label">
+                  {axis.toUpperCase()}
+                </label>
+                <div className="property-value">
+                  <input
+                    id={`loc-${axis}`}
+                    type="number"
+                    className="property-input"
+                    defaultValue={axis === 'x' ? x.toFixed(1) : axis === 'y' ? y.toFixed(1) : z.toFixed(1)}
+                    onBlur={(e) => handleLocationBlur(axis, e.target.value)}
+                  />
+                </div>
+              </div>
+            ))}
           </div>
-          <div className="property-row">
-            <span className="property-label">Y</span>
-            <div className="property-value">
-              <input
-                type="number"
-                className="property-input"
-                value={selectedElement.transform.translation.y.toFixed(1)}
-              />
-            </div>
-          </div>
-          <div className="property-row">
-            <span className="property-label">Z</span>
-            <div className="property-value">
-              <input
-                type="number"
-                className="property-input"
-                value={selectedElement.transform.translation.z.toFixed(1)}
-              />
-            </div>
-          </div>
-        </div>
+        )}
 
         <div className="property-group">
           <div className="property-group-title">Dimensions</div>
-          {Object.entries(selectedElement.properties).map(([key, prop]) => (
+          {Object.entries(sharedProperties).map(([key, prop]) => (
             <div key={key} className="property-row">
               <span className="property-label">{key}</span>
-              <div className="property-value">
+              <div className="property-value property-value-with-unit">
                 <input
-                  type="text"
+                  type={prop.type === 'number' ? 'number' : 'text'}
                   className="property-input"
-                  value={`${prop.value}${prop.unit ? ' ' + prop.unit : ''}`}
+                  value={getDisplayValue(key, prop)}
+                  onChange={(e) => handlePropertyChange(key, e.target.value)}
+                  onBlur={(e) => handlePropertyBlur(key, prop, e.target.value)}
                 />
+                {prop.unit && <span className="property-unit">{prop.unit}</span>}
               </div>
             </div>
           ))}
+        </div>
+
+        <div className="property-group-actions">
+          <button className="btn-add-property" onClick={handleAddProperty} aria-label="Add property">
+            + Add Property
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Replaces stub `PropertiesPanel` with a fully editable properties panel
- Single-select: shows element type, X/Y/Z location inputs, all element properties with type-appropriate inputs and unit labels
- Multi-select: shows count summary and shared properties, edits applied to all selected elements simultaneously
- Each edit triggers `pushHistory` for undo/redo support
- `+ Add Property` button adds a custom string property to selected element(s)

## Test plan

- [ ] `PropertiesPanel.test.tsx` — 15 tests covering all acceptance criteria
- [ ] All 125 app tests passing
- [ ] TypeScript typecheck clean

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)