### PR TITLE
feat(app): T-SHEET-001 sheet layout panel — title block, scale, PDF export

### DIFF
--- a/packages/app/src/components/SheetPanel.test.tsx
+++ b/packages/app/src/components/SheetPanel.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SheetPanel } from './SheetPanel';
+
+describe('T-SHEET-001: SheetPanel', () => {
+  const defaultProps = {
+    onExportPDF: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the Sheet Layout header', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByText('Sheet Layout')).toBeInTheDocument();
+  });
+
+  it('shows sheet size select', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByLabelText(/sheet size/i)).toBeInTheDocument();
+  });
+
+  it('sheet size options include A0, A1, A2, A3, A4', () => {
+    render(<SheetPanel {...defaultProps} />);
+    const select = screen.getByLabelText(/sheet size/i);
+    const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+    expect(options).toContain('A0');
+    expect(options).toContain('A1');
+    expect(options).toContain('A2');
+    expect(options).toContain('A3');
+    expect(options).toContain('A4');
+  });
+
+  it('shows title block fields', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByLabelText(/project name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/drawn by/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sheet number/i)).toBeInTheDocument();
+  });
+
+  it('shows orientation select (Portrait/Landscape)', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByLabelText(/orientation/i)).toBeInTheDocument();
+    const select = screen.getByLabelText(/orientation/i);
+    const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+    expect(options).toContain('Portrait');
+    expect(options).toContain('Landscape');
+  });
+
+  it('shows scale select', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByLabelText(/scale/i)).toBeInTheDocument();
+  });
+
+  it('scale options include common architectural scales', () => {
+    render(<SheetPanel {...defaultProps} />);
+    const select = screen.getByLabelText(/scale/i);
+    const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+    expect(options).toContain('1:50');
+    expect(options).toContain('1:100');
+  });
+
+  it('shows Export PDF button', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /export.*pdf/i })).toBeInTheDocument();
+  });
+
+  it('calls onExportPDF when Export PDF button clicked', () => {
+    render(<SheetPanel {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /export.*pdf/i }));
+    expect(defaultProps.onExportPDF).toHaveBeenCalled();
+  });
+
+  it('calls onExportPDF with sheet config', () => {
+    render(<SheetPanel {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /export.*pdf/i }));
+    expect(defaultProps.onExportPDF).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: expect.any(String),
+        orientation: expect.any(String),
+        scale: expect.any(String),
+      })
+    );
+  });
+
+  it('shows sheet preview area', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByRole('img', { name: /sheet preview/i })).toBeInTheDocument();
+  });
+
+  it('shows Add View button', () => {
+    render(<SheetPanel {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /add view/i })).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/SheetPanel.tsx
+++ b/packages/app/src/components/SheetPanel.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+
+const SHEET_SIZES = ['A0', 'A1', 'A2', 'A3', 'A4'];
+const ORIENTATIONS = ['Portrait', 'Landscape'];
+const SCALES = ['1:1', '1:5', '1:10', '1:20', '1:50', '1:100', '1:200', '1:500'];
+
+export interface SheetConfig {
+  size: string;
+  orientation: string;
+  scale: string;
+  projectName: string;
+  drawnBy: string;
+  sheetNumber: string;
+}
+
+interface SheetPanelProps {
+  onExportPDF: (config: SheetConfig) => void;
+}
+
+export function SheetPanel({ onExportPDF }: SheetPanelProps) {
+  const [size, setSize] = useState('A1');
+  const [orientation, setOrientation] = useState('Landscape');
+  const [scale, setScale] = useState('1:100');
+  const [projectName, setProjectName] = useState('');
+  const [drawnBy, setDrawnBy] = useState('');
+  const [sheetNumber, setSheetNumber] = useState('A1-01');
+
+  const handleExport = () => {
+    onExportPDF({ size, orientation, scale, projectName, drawnBy, sheetNumber });
+  };
+
+  // Approximate sheet ratio for preview
+  const isLandscape = orientation === 'Landscape';
+  const previewW = isLandscape ? 160 : 110;
+  const previewH = isLandscape ? 110 : 160;
+
+  return (
+    <div className="sheet-panel">
+      <div className="panel-header">
+        <span className="panel-title">Sheet Layout</span>
+      </div>
+
+      <div className="sheet-controls">
+        <div className="sheet-row">
+          <label htmlFor="sheet-size">Sheet Size</label>
+          <select
+            id="sheet-size"
+            aria-label="Sheet Size"
+            value={size}
+            onChange={(e) => setSize(e.target.value)}
+            className="sheet-select"
+          >
+            {SHEET_SIZES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="sheet-row">
+          <label htmlFor="sheet-orientation">Orientation</label>
+          <select
+            id="sheet-orientation"
+            aria-label="Orientation"
+            value={orientation}
+            onChange={(e) => setOrientation(e.target.value)}
+            className="sheet-select"
+          >
+            {ORIENTATIONS.map((o) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="sheet-row">
+          <label htmlFor="sheet-scale">Scale</label>
+          <select
+            id="sheet-scale"
+            aria-label="Scale"
+            value={scale}
+            onChange={(e) => setScale(e.target.value)}
+            className="sheet-select"
+          >
+            {SCALES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="sheet-title-block">
+        <div className="sheet-row">
+          <label htmlFor="sheet-project-name">Project Name</label>
+          <input
+            id="sheet-project-name"
+            type="text"
+            value={projectName}
+            onChange={(e) => setProjectName(e.target.value)}
+            className="sheet-input"
+            placeholder="Project name"
+          />
+        </div>
+        <div className="sheet-row">
+          <label htmlFor="sheet-drawn-by">Drawn By</label>
+          <input
+            id="sheet-drawn-by"
+            type="text"
+            value={drawnBy}
+            onChange={(e) => setDrawnBy(e.target.value)}
+            className="sheet-input"
+            placeholder="Initials"
+          />
+        </div>
+        <div className="sheet-row">
+          <label htmlFor="sheet-number">Sheet Number</label>
+          <input
+            id="sheet-number"
+            type="text"
+            value={sheetNumber}
+            onChange={(e) => setSheetNumber(e.target.value)}
+            className="sheet-input"
+          />
+        </div>
+      </div>
+
+      <div className="sheet-preview-wrapper">
+        <div
+          role="img"
+          aria-label="Sheet preview"
+          className="sheet-preview"
+          style={{ width: previewW, height: previewH }}
+        >
+          <div className="sheet-preview-title-block">
+            <span className="sheet-preview-project">{projectName || 'Project'}</span>
+            <span className="sheet-preview-number">{sheetNumber}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="sheet-actions">
+        <button
+          className="btn-secondary"
+          onClick={() => {}}
+          aria-label="Add View"
+        >
+          Add View
+        </button>
+        <button
+          className="btn-primary"
+          onClick={handleExport}
+          aria-label="Export PDF"
+        >
+          Export PDF
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `SheetPanel` component with sheet size (A0–A4), orientation (Portrait/Landscape), and scale (1:1 through 1:500) selectors
- Title block fields: project name, drawn by, sheet number
- Sheet preview thumbnail that updates with orientation (portrait/landscape proportions)
- **Add View** button for future viewport placement support
- **Export PDF** fires `onExportPDF(config)` callback with full sheet configuration

## Test plan

- [ ] `SheetPanel.test.tsx` — 12 tests covering all acceptance criteria
- [ ] All 122 app tests passing
- [ ] TypeScript typecheck clean

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)