### PR TITLE
feat(app): T-MAT-001 material library — 100 standard finishes, searchable

### DIFF
--- a/packages/app/src/components/MaterialLibrary.test.tsx
+++ b/packages/app/src/components/MaterialLibrary.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MaterialLibrary } from './MaterialLibrary';
+
+describe('T-MAT-001: MaterialLibrary', () => {
+  const defaultProps = {
+    onSelect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders Material Library header', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    expect(screen.getByText('Material Library')).toBeInTheDocument();
+  });
+
+  it('shows search input', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    expect(screen.getByPlaceholderText(/search materials/i)).toBeInTheDocument();
+  });
+
+  it('shows category filter', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    expect(screen.getByRole('combobox', { name: /category/i })).toBeInTheDocument();
+  });
+
+  it('has at least 100 built-in materials', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    const cards = screen.getAllByRole('button', { name: /select/i });
+    expect(cards.length).toBeGreaterThanOrEqual(100);
+  });
+
+  it('shows material name', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    // "Concrete" appears as name and category tag — use getAllByText
+    expect(screen.getAllByText('Concrete').length).toBeGreaterThan(0);
+  });
+
+  it('shows material cost per m²', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    expect(screen.getAllByText(/\/m²/).length).toBeGreaterThan(0);
+  });
+
+  it('filters materials by search query', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/search materials/i);
+    fireEvent.change(input, { target: { value: 'brick' } });
+    // Multiple brick materials expected — check at least one card is shown
+    expect(screen.getAllByText(/brick/i).length).toBeGreaterThan(0);
+  });
+
+  it('hides non-matching materials when searching', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/search materials/i);
+    fireEvent.change(input, { target: { value: 'zzz_nomatch' } });
+    // Material cards should be gone; only the empty state should appear
+    expect(screen.queryByText('Mild Steel')).not.toBeInTheDocument();
+    expect(screen.getByText(/no materials found/i)).toBeInTheDocument();
+  });
+
+  it('filters by category', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    const select = screen.getByRole('combobox', { name: /category/i });
+    fireEvent.change(select, { target: { value: 'Concrete' } });
+    const cards = screen.getAllByRole('button', { name: /select/i });
+    expect(cards.length).toBeGreaterThan(0);
+  });
+
+  it('calls onSelect when a material is clicked', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    const firstSelect = screen.getAllByRole('button', { name: /select/i })[0];
+    fireEvent.click(firstSelect!);
+    expect(defaultProps.onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expect.any(String),
+        category: expect.any(String),
+        costPerM2: expect.any(Number),
+      })
+    );
+  });
+
+  it('shows Add Custom Material button', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /add custom/i })).toBeInTheDocument();
+  });
+
+  it('shows empty state when no materials match', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/search materials/i);
+    fireEvent.change(input, { target: { value: 'zzz_nomatch' } });
+    expect(screen.getByText(/no materials found/i)).toBeInTheDocument();
+  });
+
+  it('shows roughness value for materials', () => {
+    render(<MaterialLibrary {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/search materials/i);
+    fireEvent.change(input, { target: { value: 'concrete' } });
+    expect(screen.getAllByText(/roughness/i).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/components/MaterialLibrary.tsx
+++ b/packages/app/src/components/MaterialLibrary.tsx
@@ -1,0 +1,96 @@
+import React, { useState, useMemo } from 'react';
+import { BUILT_IN_MATERIALS, MATERIAL_CATEGORIES, type Material } from '../lib/materials';
+
+interface MaterialLibraryProps {
+  onSelect: (material: Material) => void;
+}
+
+export function MaterialLibrary({ onSelect }: MaterialLibraryProps) {
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState('All');
+
+  const filtered = useMemo(() => {
+    return BUILT_IN_MATERIALS.filter((m) => {
+      const matchesSearch =
+        search === '' || m.name.toLowerCase().includes(search.toLowerCase());
+      const matchesCategory = category === 'All' || m.category === category;
+      return matchesSearch && matchesCategory;
+    });
+  }, [search, category]);
+
+  return (
+    <div className="material-library">
+      <div className="panel-header">
+        <span className="panel-title">Material Library</span>
+      </div>
+
+      <div className="material-library-controls">
+        <input
+          type="text"
+          className="material-search"
+          placeholder="Search materials…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+
+        <label htmlFor="material-category" className="sr-only">
+          Category
+        </label>
+        <select
+          id="material-category"
+          aria-label="Category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="material-category-select"
+        >
+          <option value="All">All Categories</option>
+          {MATERIAL_CATEGORIES.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="material-empty">No materials found</div>
+      ) : (
+        <div className="material-grid">
+          {filtered.map((mat) => (
+            <div key={mat.id} className="material-card">
+              <div
+                className="material-swatch"
+                style={{ backgroundColor: mat.color }}
+                aria-hidden="true"
+              />
+              <div className="material-info">
+                <span className="material-name">{mat.name}</span>
+                <span className="material-category-tag">{mat.category}</span>
+                <span className="material-roughness">roughness: {mat.roughness.toFixed(2)}</span>
+                <span className="material-cost">
+                  ${mat.costPerM2}/m²
+                </span>
+              </div>
+              <button
+                className="btn-select-material"
+                onClick={() => onSelect(mat)}
+                aria-label={`Select ${mat.name}`}
+              >
+                Select
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="material-library-footer">
+        <button
+          className="btn-secondary"
+          aria-label="Add custom material"
+        >
+          + Add Custom
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/lib/materials.ts
+++ b/packages/app/src/lib/materials.ts
@@ -1,0 +1,145 @@
+export interface Material {
+  id: string;
+  name: string;
+  category: string;
+  roughness: number;
+  metalness: number;
+  costPerM2: number;
+  unit: string;
+  color: string; // hex fallback when texture unavailable
+}
+
+// ≥100 standard architectural materials
+export const BUILT_IN_MATERIALS: Material[] = [
+  // Concrete
+  { id: 'concrete-standard', name: 'Concrete', category: 'Concrete', roughness: 0.9, metalness: 0.0, costPerM2: 45, unit: 'm²', color: '#9e9e9e' },
+  { id: 'concrete-polished', name: 'Polished Concrete', category: 'Concrete', roughness: 0.2, metalness: 0.0, costPerM2: 95, unit: 'm²', color: '#bdbdbd' },
+  { id: 'concrete-exposed', name: 'Exposed Concrete', category: 'Concrete', roughness: 0.85, metalness: 0.0, costPerM2: 55, unit: 'm²', color: '#9e9e9e' },
+  { id: 'concrete-precast', name: 'Precast Concrete', category: 'Concrete', roughness: 0.8, metalness: 0.0, costPerM2: 80, unit: 'm²', color: '#aeaeae' },
+  { id: 'concrete-reinforced', name: 'Reinforced Concrete', category: 'Concrete', roughness: 0.9, metalness: 0.1, costPerM2: 60, unit: 'm²', color: '#9e9e9e' },
+  { id: 'concrete-white', name: 'White Concrete', category: 'Concrete', roughness: 0.75, metalness: 0.0, costPerM2: 70, unit: 'm²', color: '#e8e8e8' },
+  { id: 'concrete-stamped', name: 'Stamped Concrete', category: 'Concrete', roughness: 0.8, metalness: 0.0, costPerM2: 110, unit: 'm²', color: '#b0a090' },
+  { id: 'concrete-lightweight', name: 'Lightweight Concrete', category: 'Concrete', roughness: 0.9, metalness: 0.0, costPerM2: 65, unit: 'm²', color: '#c0c0c0' },
+
+  // Brick
+  { id: 'brick-red', name: 'Brick - Red', category: 'Masonry', roughness: 0.95, metalness: 0.0, costPerM2: 85, unit: 'm²', color: '#b55239' },
+  { id: 'brick-facing', name: 'Facing Brick', category: 'Masonry', roughness: 0.9, metalness: 0.0, costPerM2: 120, unit: 'm²', color: '#c06040' },
+  { id: 'brick-engineering', name: 'Engineering Brick', category: 'Masonry', roughness: 0.85, metalness: 0.0, costPerM2: 100, unit: 'm²', color: '#8b3a2a' },
+  { id: 'brick-reclaimed', name: 'Reclaimed Brick', category: 'Masonry', roughness: 0.95, metalness: 0.0, costPerM2: 150, unit: 'm²', color: '#a0522d' },
+  { id: 'blockwork-concrete', name: 'Concrete Blockwork', category: 'Masonry', roughness: 0.9, metalness: 0.0, costPerM2: 50, unit: 'm²', color: '#a0a0a0' },
+  { id: 'stone-limestone', name: 'Limestone', category: 'Masonry', roughness: 0.85, metalness: 0.0, costPerM2: 200, unit: 'm²', color: '#d4c9a8' },
+  { id: 'stone-sandstone', name: 'Sandstone', category: 'Masonry', roughness: 0.9, metalness: 0.0, costPerM2: 180, unit: 'm²', color: '#c8a87a' },
+  { id: 'stone-granite', name: 'Granite', category: 'Masonry', roughness: 0.3, metalness: 0.0, costPerM2: 350, unit: 'm²', color: '#808080' },
+  { id: 'stone-marble', name: 'Marble', category: 'Masonry', roughness: 0.1, metalness: 0.0, costPerM2: 500, unit: 'm²', color: '#f5f5f5' },
+  { id: 'stone-slate', name: 'Slate', category: 'Masonry', roughness: 0.7, metalness: 0.0, costPerM2: 250, unit: 'm²', color: '#5a5a6a' },
+
+  // Timber
+  { id: 'timber-oak', name: 'Oak Timber', category: 'Timber', roughness: 0.8, metalness: 0.0, costPerM2: 120, unit: 'm²', color: '#8b6914' },
+  { id: 'timber-pine', name: 'Pine Timber', category: 'Timber', roughness: 0.75, metalness: 0.0, costPerM2: 60, unit: 'm²', color: '#d4a855' },
+  { id: 'timber-walnut', name: 'Walnut Timber', category: 'Timber', roughness: 0.7, metalness: 0.0, costPerM2: 200, unit: 'm²', color: '#5c3d1e' },
+  { id: 'timber-maple', name: 'Maple Timber', category: 'Timber', roughness: 0.7, metalness: 0.0, costPerM2: 140, unit: 'm²', color: '#deb887' },
+  { id: 'timber-cedar', name: 'Cedar Timber', category: 'Timber', roughness: 0.8, metalness: 0.0, costPerM2: 100, unit: 'm²', color: '#c17f3b' },
+  { id: 'timber-ash', name: 'Ash Timber', category: 'Timber', roughness: 0.75, metalness: 0.0, costPerM2: 130, unit: 'm²', color: '#c8b898' },
+  { id: 'timber-bamboo', name: 'Bamboo', category: 'Timber', roughness: 0.7, metalness: 0.0, costPerM2: 80, unit: 'm²', color: '#a8b830' },
+  { id: 'plywood-standard', name: 'Plywood', category: 'Timber', roughness: 0.8, metalness: 0.0, costPerM2: 40, unit: 'm²', color: '#c8a878' },
+  { id: 'mdf', name: 'MDF', category: 'Timber', roughness: 0.85, metalness: 0.0, costPerM2: 25, unit: 'm²', color: '#d8c8a8' },
+  { id: 'osb', name: 'OSB', category: 'Timber', roughness: 0.9, metalness: 0.0, costPerM2: 20, unit: 'm²', color: '#c0a850' },
+  { id: 'glulam', name: 'Glulam', category: 'Timber', roughness: 0.7, metalness: 0.0, costPerM2: 160, unit: 'm²', color: '#b8943c' },
+
+  // Steel
+  { id: 'steel-mild', name: 'Mild Steel', category: 'Metal', roughness: 0.4, metalness: 0.9, costPerM2: 150, unit: 'm²', color: '#808080' },
+  { id: 'steel-stainless', name: 'Stainless Steel', category: 'Metal', roughness: 0.15, metalness: 0.95, costPerM2: 350, unit: 'm²', color: '#c8c8c8' },
+  { id: 'steel-corten', name: 'Corten Steel', category: 'Metal', roughness: 0.85, metalness: 0.7, costPerM2: 250, unit: 'm²', color: '#8b4513' },
+  { id: 'steel-galvanised', name: 'Galvanised Steel', category: 'Metal', roughness: 0.35, metalness: 0.85, costPerM2: 180, unit: 'm²', color: '#a0a8b0' },
+  { id: 'aluminum-standard', name: 'Aluminium', category: 'Metal', roughness: 0.25, metalness: 0.9, costPerM2: 200, unit: 'm²', color: '#b8b8c0' },
+  { id: 'aluminum-anodised', name: 'Anodised Aluminium', category: 'Metal', roughness: 0.2, metalness: 0.85, costPerM2: 280, unit: 'm²', color: '#90a0b0' },
+  { id: 'copper', name: 'Copper', category: 'Metal', roughness: 0.3, metalness: 0.9, costPerM2: 400, unit: 'm²', color: '#b87333' },
+  { id: 'brass', name: 'Brass', category: 'Metal', roughness: 0.3, metalness: 0.85, costPerM2: 300, unit: 'm²', color: '#b5a642' },
+  { id: 'zinc', name: 'Zinc', category: 'Metal', roughness: 0.4, metalness: 0.8, costPerM2: 220, unit: 'm²', color: '#8090a0' },
+  { id: 'cast-iron', name: 'Cast Iron', category: 'Metal', roughness: 0.7, metalness: 0.85, costPerM2: 180, unit: 'm²', color: '#404040' },
+
+  // Glass
+  { id: 'glass-clear', name: 'Clear Glass', category: 'Glass', roughness: 0.05, metalness: 0.0, costPerM2: 80, unit: 'm²', color: '#d0e8f0' },
+  { id: 'glass-frosted', name: 'Frosted Glass', category: 'Glass', roughness: 0.8, metalness: 0.0, costPerM2: 120, unit: 'm²', color: '#e0f0f8' },
+  { id: 'glass-tinted', name: 'Tinted Glass', category: 'Glass', roughness: 0.05, metalness: 0.0, costPerM2: 100, unit: 'm²', color: '#88a8b0' },
+  { id: 'glass-tempered', name: 'Tempered Glass', category: 'Glass', roughness: 0.05, metalness: 0.0, costPerM2: 150, unit: 'm²', color: '#c8e8f0' },
+  { id: 'glass-laminated', name: 'Laminated Glass', category: 'Glass', roughness: 0.05, metalness: 0.0, costPerM2: 200, unit: 'm²', color: '#c0e0f0' },
+  { id: 'glass-double-glazed', name: 'Double Glazed', category: 'Glass', roughness: 0.05, metalness: 0.0, costPerM2: 180, unit: 'm²', color: '#d0e8f8' },
+  { id: 'glass-low-e', name: 'Low-E Glass', category: 'Glass', roughness: 0.05, metalness: 0.1, costPerM2: 250, unit: 'm²', color: '#c8e0f0' },
+  { id: 'glass-mirror', name: 'Mirror', category: 'Glass', roughness: 0.02, metalness: 0.9, costPerM2: 160, unit: 'm²', color: '#e8e8e8' },
+
+  // Plasterboard / Drywall
+  { id: 'plasterboard-standard', name: 'Plasterboard', category: 'Plaster', roughness: 0.9, metalness: 0.0, costPerM2: 15, unit: 'm²', color: '#f0f0e0' },
+  { id: 'plasterboard-moisture', name: 'Moisture Resistant Board', category: 'Plaster', roughness: 0.9, metalness: 0.0, costPerM2: 25, unit: 'm²', color: '#d0f0d0' },
+  { id: 'plasterboard-fire', name: 'Fire Rated Board', category: 'Plaster', roughness: 0.9, metalness: 0.0, costPerM2: 30, unit: 'm²', color: '#f0e0e0' },
+  { id: 'render-sand-cement', name: 'Sand/Cement Render', category: 'Plaster', roughness: 0.85, metalness: 0.0, costPerM2: 35, unit: 'm²', color: '#d8d0c0' },
+  { id: 'render-lime', name: 'Lime Render', category: 'Plaster', roughness: 0.8, metalness: 0.0, costPerM2: 45, unit: 'm²', color: '#e8e0d0' },
+  { id: 'skim-coat', name: 'Skim Coat Plaster', category: 'Plaster', roughness: 0.6, metalness: 0.0, costPerM2: 20, unit: 'm²', color: '#f5f5f0' },
+
+  // Roofing
+  { id: 'roof-tiles-clay', name: 'Clay Roof Tiles', category: 'Roofing', roughness: 0.9, metalness: 0.0, costPerM2: 80, unit: 'm²', color: '#b05030' },
+  { id: 'roof-tiles-concrete', name: 'Concrete Roof Tiles', category: 'Roofing', roughness: 0.85, metalness: 0.0, costPerM2: 55, unit: 'm²', color: '#808080' },
+  { id: 'roof-slate', name: 'Roof Slate', category: 'Roofing', roughness: 0.75, metalness: 0.0, costPerM2: 180, unit: 'm²', color: '#505060' },
+  { id: 'roof-felt', name: 'Felt Roofing', category: 'Roofing', roughness: 0.9, metalness: 0.0, costPerM2: 30, unit: 'm²', color: '#303030' },
+  { id: 'roof-metal-standing-seam', name: 'Standing Seam Metal Roof', category: 'Roofing', roughness: 0.4, metalness: 0.8, costPerM2: 200, unit: 'm²', color: '#c0c8d0' },
+  { id: 'roof-green', name: 'Green Roof', category: 'Roofing', roughness: 0.95, metalness: 0.0, costPerM2: 250, unit: 'm²', color: '#4a8a4a' },
+  { id: 'roof-bitumen', name: 'Bitumen Roofing', category: 'Roofing', roughness: 0.9, metalness: 0.0, costPerM2: 45, unit: 'm²', color: '#202020' },
+
+  // Flooring
+  { id: 'floor-ceramic-tile', name: 'Ceramic Floor Tile', category: 'Flooring', roughness: 0.3, metalness: 0.0, costPerM2: 50, unit: 'm²', color: '#d0c8b8' },
+  { id: 'floor-porcelain-tile', name: 'Porcelain Tile', category: 'Flooring', roughness: 0.2, metalness: 0.0, costPerM2: 80, unit: 'm²', color: '#e0d8c8' },
+  { id: 'floor-vinyl', name: 'Vinyl Flooring', category: 'Flooring', roughness: 0.5, metalness: 0.0, costPerM2: 25, unit: 'm²', color: '#c8c0b0' },
+  { id: 'floor-laminate', name: 'Laminate Flooring', category: 'Flooring', roughness: 0.5, metalness: 0.0, costPerM2: 30, unit: 'm²', color: '#b8a068' },
+  { id: 'floor-engineered-wood', name: 'Engineered Wood', category: 'Flooring', roughness: 0.6, metalness: 0.0, costPerM2: 70, unit: 'm²', color: '#a87840' },
+  { id: 'floor-solid-wood', name: 'Solid Wood Floor', category: 'Flooring', roughness: 0.65, metalness: 0.0, costPerM2: 120, unit: 'm²', color: '#9c6830' },
+  { id: 'floor-carpet', name: 'Carpet', category: 'Flooring', roughness: 0.98, metalness: 0.0, costPerM2: 35, unit: 'm²', color: '#b0a890' },
+  { id: 'floor-epoxy', name: 'Epoxy Floor', category: 'Flooring', roughness: 0.15, metalness: 0.0, costPerM2: 60, unit: 'm²', color: '#d0d8e0' },
+
+  // Insulation
+  { id: 'insulation-mineral-wool', name: 'Mineral Wool', category: 'Insulation', roughness: 0.98, metalness: 0.0, costPerM2: 15, unit: 'm²', color: '#f0e8b0' },
+  { id: 'insulation-rigid-foam', name: 'Rigid Foam (PIR)', category: 'Insulation', roughness: 0.95, metalness: 0.0, costPerM2: 25, unit: 'm²', color: '#f0f050' },
+  { id: 'insulation-eps', name: 'EPS Insulation', category: 'Insulation', roughness: 0.95, metalness: 0.0, costPerM2: 12, unit: 'm²', color: '#f8f8f8' },
+  { id: 'insulation-spray-foam', name: 'Spray Foam Insulation', category: 'Insulation', roughness: 0.95, metalness: 0.0, costPerM2: 40, unit: 'm²', color: '#ffe880' },
+
+  // Paint / Finish
+  { id: 'paint-white-matte', name: 'White Matte Paint', category: 'Paint', roughness: 0.95, metalness: 0.0, costPerM2: 8, unit: 'm²', color: '#ffffff' },
+  { id: 'paint-white-gloss', name: 'White Gloss Paint', category: 'Paint', roughness: 0.2, metalness: 0.0, costPerM2: 10, unit: 'm²', color: '#f8f8f8' },
+  { id: 'paint-dark-matte', name: 'Dark Matte Paint', category: 'Paint', roughness: 0.95, metalness: 0.0, costPerM2: 8, unit: 'm²', color: '#303030' },
+  { id: 'paint-satin', name: 'Satin Paint', category: 'Paint', roughness: 0.5, metalness: 0.0, costPerM2: 9, unit: 'm²', color: '#e8e8e8' },
+  { id: 'wallpaper-plain', name: 'Plain Wallpaper', category: 'Paint', roughness: 0.85, metalness: 0.0, costPerM2: 20, unit: 'm²', color: '#f0e8d8' },
+  { id: 'wallpaper-textured', name: 'Textured Wallpaper', category: 'Paint', roughness: 0.9, metalness: 0.0, costPerM2: 35, unit: 'm²', color: '#e8d8c0' },
+
+  // Cladding
+  { id: 'cladding-timber', name: 'Timber Cladding', category: 'Cladding', roughness: 0.85, metalness: 0.0, costPerM2: 90, unit: 'm²', color: '#a87840' },
+  { id: 'cladding-fibre-cement', name: 'Fibre Cement Board', category: 'Cladding', roughness: 0.8, metalness: 0.0, costPerM2: 75, unit: 'm²', color: '#c8c0b0' },
+  { id: 'cladding-metal-panel', name: 'Metal Panel Cladding', category: 'Cladding', roughness: 0.35, metalness: 0.8, costPerM2: 180, unit: 'm²', color: '#a8b0b8' },
+  { id: 'cladding-rainscreen', name: 'Rainscreen Cladding', category: 'Cladding', roughness: 0.4, metalness: 0.7, costPerM2: 200, unit: 'm²', color: '#909098' },
+  { id: 'cladding-terracotta', name: 'Terracotta Cladding', category: 'Cladding', roughness: 0.85, metalness: 0.0, costPerM2: 250, unit: 'm²', color: '#c06040' },
+  { id: 'cladding-hpl', name: 'HPL Panel', category: 'Cladding', roughness: 0.4, metalness: 0.0, costPerM2: 160, unit: 'm²', color: '#d0c8b8' },
+
+  // Waterproofing
+  { id: 'waterproof-membrane', name: 'Waterproof Membrane', category: 'Waterproofing', roughness: 0.9, metalness: 0.0, costPerM2: 30, unit: 'm²', color: '#303030' },
+  { id: 'tanking', name: 'Tanking Slurry', category: 'Waterproofing', roughness: 0.9, metalness: 0.0, costPerM2: 25, unit: 'm²', color: '#909090' },
+
+  // Acoustic
+  { id: 'acoustic-panel', name: 'Acoustic Panel', category: 'Acoustic', roughness: 0.98, metalness: 0.0, costPerM2: 80, unit: 'm²', color: '#d8c8b0' },
+  { id: 'acoustic-foam', name: 'Acoustic Foam', category: 'Acoustic', roughness: 0.98, metalness: 0.0, costPerM2: 40, unit: 'm²', color: '#a0b0a0' },
+  { id: 'acoustic-plasterboard', name: 'Acoustic Plasterboard', category: 'Acoustic', roughness: 0.9, metalness: 0.0, costPerM2: 35, unit: 'm²', color: '#e8e0d8' },
+
+  // Specialist
+  { id: 'terracotta-tile', name: 'Terracotta Tile', category: 'Tile', roughness: 0.85, metalness: 0.0, costPerM2: 90, unit: 'm²', color: '#c06840' },
+  { id: 'mosaic-tile', name: 'Mosaic Tile', category: 'Tile', roughness: 0.3, metalness: 0.0, costPerM2: 120, unit: 'm²', color: '#8090a8' },
+  { id: 'travertine', name: 'Travertine', category: 'Masonry', roughness: 0.6, metalness: 0.0, costPerM2: 300, unit: 'm²', color: '#e0d0b0' },
+  { id: 'onyx', name: 'Onyx', category: 'Masonry', roughness: 0.15, metalness: 0.0, costPerM2: 800, unit: 'm²', color: '#c8b890' },
+  { id: 'polycarbonate', name: 'Polycarbonate Panel', category: 'Glass', roughness: 0.3, metalness: 0.0, costPerM2: 60, unit: 'm²', color: '#d0e8f8' },
+  { id: 'etfe', name: 'ETFE Cushion', category: 'Glass', roughness: 0.1, metalness: 0.0, costPerM2: 350, unit: 'm²', color: '#e8f4fc' },
+  { id: 'stone-basalt', name: 'Basalt', category: 'Masonry', roughness: 0.8, metalness: 0.0, costPerM2: 220, unit: 'm²', color: '#404040' },
+  { id: 'steel-perforated', name: 'Perforated Steel', category: 'Metal', roughness: 0.45, metalness: 0.85, costPerM2: 200, unit: 'm²', color: '#909090' },
+  { id: 'timber-larch', name: 'Larch Timber', category: 'Timber', roughness: 0.8, metalness: 0.0, costPerM2: 95, unit: 'm²', color: '#c09050' },
+  { id: 'render-acrylic', name: 'Acrylic Render', category: 'Plaster', roughness: 0.7, metalness: 0.0, costPerM2: 55, unit: 'm²', color: '#e8e0d0' },
+  { id: 'floor-resin', name: 'Resin Floor', category: 'Flooring', roughness: 0.1, metalness: 0.0, costPerM2: 75, unit: 'm²', color: '#d8e0e8' },
+];
+
+export const MATERIAL_CATEGORIES = Array.from(
+  new Set(BUILT_IN_MATERIALS.map((m) => m.category))
+).sort();


### PR DESCRIPTION
## Summary

- `BUILT_IN_MATERIALS` data (100 materials) in `src/lib/materials.ts` across 12 categories: Concrete, Masonry, Timber, Metal, Glass, Plaster, Roofing, Flooring, Insulation, Paint, Cladding, Acoustic
- Each material has: `name`, `category`, `roughness`, `metalness`, `costPerM2`, `unit`, `color` (PBR hex fallback)
- `MaterialLibrary` component with text search + category filter dropdown
- Material cards show swatch (color block), name, category, roughness, and cost/m²
- `Select` button fires `onSelect(material)` callback for element assignment
- `+ Add Custom` button placeholder for project-specific materials
- Empty state when no materials match query

## Test plan

- [ ] `MaterialLibrary.test.tsx` — 13 tests covering all acceptance criteria
- [ ] At least 100 built-in materials verified in test
- [ ] All 123 app tests passing
- [ ] TypeScript typecheck clean

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)