### PR TITLE
feat(app): T-2D-010 Symbol Library component

### DIFF
--- a/packages/app/src/components/SymbolLibrary.test.tsx
+++ b/packages/app/src/components/SymbolLibrary.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SymbolLibrary } from './SymbolLibrary';
+
+describe('T-2D-010: SymbolLibrary', () => {
+  const defaultProps = { onInsert: vi.fn() };
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders Symbol Library header', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getByText('Symbol Library')).toBeInTheDocument();
+  });
+
+  it('shows North Arrow symbol', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getAllByText(/north arrow/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Scale Bar symbol', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getAllByText(/scale bar/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Revision Cloud symbol', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getAllByText(/revision cloud/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Break Line symbol', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getAllByText(/break line/i).length).toBeGreaterThan(0);
+  });
+
+  it('has Insert button for each symbol', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getAllByRole('button', { name: /insert/i }).length).toBeGreaterThan(0);
+  });
+
+  it('calls onInsert when Insert clicked', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /insert/i })[0]!);
+    expect(defaultProps.onInsert).toHaveBeenCalledWith(expect.objectContaining({ id: expect.any(String) }));
+  });
+
+  it('shows search input', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+  });
+
+  it('filters symbols by search', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    const input = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(input, { target: { value: 'north' } });
+    expect(screen.getAllByText(/north arrow/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows at least 10 symbols', () => {
+    render(<SymbolLibrary {...defaultProps} />);
+    expect(screen.getAllByRole('button', { name: /insert/i }).length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/app/src/components/SymbolLibrary.tsx
+++ b/packages/app/src/components/SymbolLibrary.tsx
@@ -1,0 +1,54 @@
+import React, { useState, useMemo } from 'react';
+
+export interface Symbol2D { id: string; name: string; category: string; description: string; }
+
+const SYMBOLS: Symbol2D[] = [
+  { id: 'north-arrow', name: 'North Arrow', category: 'Annotation', description: 'True north indicator' },
+  { id: 'north-arrow-magnetic', name: 'North Arrow (Magnetic)', category: 'Annotation', description: 'Magnetic north' },
+  { id: 'scale-bar', name: 'Scale Bar', category: 'Annotation', description: 'Graphical scale bar' },
+  { id: 'revision-cloud', name: 'Revision Cloud', category: 'Annotation', description: 'Cloud markup for revisions' },
+  { id: 'break-line', name: 'Break Line', category: 'Annotation', description: 'Zigzag break line' },
+  { id: 'section-marker', name: 'Section Marker', category: 'Drawing', description: 'Section cut indicator' },
+  { id: 'elevation-marker', name: 'Elevation Marker', category: 'Drawing', description: 'Elevation view indicator' },
+  { id: 'detail-bubble', name: 'Detail Bubble', category: 'Drawing', description: 'Detail reference circle' },
+  { id: 'grid-bubble', name: 'Grid Bubble', category: 'Drawing', description: 'Structural grid marker' },
+  { id: 'level-indicator', name: 'Level Indicator', category: 'Drawing', description: 'Floor level symbol' },
+  { id: 'slope-arrow', name: 'Slope Arrow', category: 'Annotation', description: 'Slope/gradient arrow' },
+  { id: 'spot-elevation', name: 'Spot Elevation', category: 'Annotation', description: 'Point elevation marker' },
+  { id: 'datum', name: 'Datum Triangle', category: 'Annotation', description: 'Elevation datum symbol' },
+  { id: 'door-swing', name: 'Door Swing Arc', category: 'Drawing', description: '90° door swing arc' },
+  { id: 'stair-arrow', name: 'Stair Direction Arrow', category: 'Drawing', description: 'Up/down stair indicator' },
+  { id: 'insulation-symbol', name: 'Insulation Symbol', category: 'Drawing', description: 'Batts insulation symbol' },
+  { id: 'cloud-note', name: 'Revision Note', category: 'Annotation', description: 'Revision delta triangle' },
+  { id: 'match-line', name: 'Match Line', category: 'Drawing', description: 'Sheet continuation line' },
+];
+
+interface SymbolLibraryProps { onInsert: (symbol: Symbol2D) => void; }
+
+export function SymbolLibrary({ onInsert }: SymbolLibraryProps) {
+  const [search, setSearch] = useState('');
+  const filtered = useMemo(() =>
+    SYMBOLS.filter((s) => !search || s.name.toLowerCase().includes(search.toLowerCase())),
+    [search]
+  );
+  return (
+    <div className="symbol-library">
+      <div className="panel-header"><span className="panel-title">Symbol Library</span></div>
+      <input type="text" placeholder="Search symbols…" value={search}
+        onChange={(e) => setSearch(e.target.value)} className="symbol-search" />
+      <div className="symbol-list">
+        {filtered.map((sym) => (
+          <div key={sym.id} className="symbol-item">
+            <div className="symbol-info">
+              <span className="symbol-name">{sym.name}</span>
+              <span className="symbol-desc">{sym.description}</span>
+            </div>
+            <button aria-label={`Insert ${sym.name}`} onClick={() => onInsert(sym)} className="btn-insert">
+              Insert
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SymbolLibrary` component with 18 architectural drawing symbols
- Search/filter functionality by symbol name
- Insert button fires `onInsert(symbol)` callback for each symbol

## Test plan
- [x] 10 unit tests passing (header, symbols present, insert buttons, onInsert callback, search/filter)
- [x] TypeScript strict mode passes

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)