### PR TITLE
feat(app): T-SYNC-011 project templates

### DIFF
--- a/packages/app/src/components/ProjectTemplates.test.tsx
+++ b/packages/app/src/components/ProjectTemplates.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { ProjectTemplates } from './ProjectTemplates';
+
+describe('T-SYNC-011: ProjectTemplates', () => {
+  const onSelect = vi.fn();
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders Project Templates header', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    expect(screen.getByText(/project templates/i)).toBeInTheDocument();
+  });
+
+  it('shows house template', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    expect(screen.getAllByText(/house/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows apartment template', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    expect(screen.getAllByText(/apartment/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows office template', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    expect(screen.getAllByText(/office/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows at least 3 templates', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    expect(screen.getAllByRole('button', { name: /use template/i }).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('calls onSelect when Use Template clicked', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /use template/i })[0]!);
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: expect.any(String) }));
+  });
+
+  it('shows Blank Project option', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    expect(screen.getAllByText(/blank/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows description for each template', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    const descs = screen.getAllByRole('button', { name: /use template/i });
+    expect(descs.length).toBeGreaterThan(0);
+  });
+
+  it('shows template level count or metadata', () => {
+    render(<ProjectTemplates onSelect={onSelect} />);
+    expect(screen.getAllByText(/level|floor|storey/i).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/components/ProjectTemplates.tsx
+++ b/packages/app/src/components/ProjectTemplates.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+
+export interface ProjectTemplate {
+  id: string;
+  name: string;
+  description: string;
+  levels: number;
+  category: string;
+  elements: { type: string; count: number }[];
+}
+
+const TEMPLATES: ProjectTemplate[] = [
+  {
+    id: 'blank',
+    name: 'Blank Project',
+    description: 'Start from scratch with an empty project.',
+    levels: 1,
+    category: 'General',
+    elements: [],
+  },
+  {
+    id: 'house-single',
+    name: 'Single Storey House',
+    description: 'Single-level residential house with living, kitchen, 3 bedrooms and 2 baths.',
+    levels: 1,
+    category: 'Residential',
+    elements: [
+      { type: 'wall', count: 24 },
+      { type: 'door', count: 8 },
+      { type: 'window', count: 12 },
+    ],
+  },
+  {
+    id: 'house-double',
+    name: 'Double Storey House',
+    description: 'Two-level family house with ground floor living and upper floor bedrooms.',
+    levels: 2,
+    category: 'Residential',
+    elements: [
+      { type: 'wall', count: 40 },
+      { type: 'door', count: 14 },
+      { type: 'window', count: 20 },
+      { type: 'slab', count: 2 },
+    ],
+  },
+  {
+    id: 'apartment',
+    name: 'Apartment / Unit',
+    description: 'Compact apartment layout with open plan living and one or two bedrooms.',
+    levels: 1,
+    category: 'Residential',
+    elements: [
+      { type: 'wall', count: 16 },
+      { type: 'door', count: 5 },
+      { type: 'window', count: 8 },
+    ],
+  },
+  {
+    id: 'apartment-block',
+    name: 'Apartment Block',
+    description: 'Multi-storey residential building with typical floor plates.',
+    levels: 6,
+    category: 'Residential',
+    elements: [
+      { type: 'wall', count: 120 },
+      { type: 'slab', count: 6 },
+      { type: 'column', count: 24 },
+    ],
+  },
+  {
+    id: 'office-open',
+    name: 'Open Plan Office',
+    description: 'Modern open plan commercial office with meeting rooms and amenities.',
+    levels: 1,
+    category: 'Commercial',
+    elements: [
+      { type: 'wall', count: 20 },
+      { type: 'door', count: 10 },
+      { type: 'window', count: 30 },
+    ],
+  },
+  {
+    id: 'office-multi',
+    name: 'Multi-Storey Office',
+    description: 'Commercial office building with typical floor plan repeated over multiple levels.',
+    levels: 5,
+    category: 'Commercial',
+    elements: [
+      { type: 'wall', count: 80 },
+      { type: 'column', count: 40 },
+      { type: 'slab', count: 5 },
+    ],
+  },
+];
+
+interface ProjectTemplatesProps {
+  onSelect: (template: ProjectTemplate) => void;
+}
+
+export function ProjectTemplates({ onSelect }: ProjectTemplatesProps) {
+  return (
+    <div className="project-templates">
+      <div className="panel-header">
+        <span className="panel-title">Project Templates</span>
+      </div>
+      <div className="templates-grid">
+        {TEMPLATES.map((tmpl) => (
+          <div key={tmpl.id} className="template-card">
+            <div className="template-info">
+              <span className="template-name">{tmpl.name}</span>
+              <span className="template-category">{tmpl.category}</span>
+              <span className="template-desc">{tmpl.description}</span>
+              <span className="template-meta">
+                {tmpl.levels} {tmpl.levels === 1 ? 'level' : 'levels'}
+                {tmpl.elements.length > 0 && ` · ${tmpl.elements.reduce((s, e) => s + e.count, 0)} elements`}
+              </span>
+            </div>
+            <button
+              aria-label={`Use template ${tmpl.name}`}
+              className="btn-use-template"
+              onClick={() => onSelect(tmpl)}
+            >
+              Use Template
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `ProjectTemplates` component with 7 starter templates (Blank, single/double storey house, apartment, apartment block, open plan office, multi-storey office)
- Each template shows name, category, description, level count, and element count
- "Use Template" button fires `onSelect(template)` callback

## Test plan
- [x] 9 unit tests passing
- [x] TypeScript strict mode passes

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)