### PR TITLE
feat(app): T-AUTH-003 permissions panel with RBAC

### DIFF
--- a/packages/app/src/components/PermissionsPanel.test.tsx
+++ b/packages/app/src/components/PermissionsPanel.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { PermissionsPanel, type ProjectMember } from './PermissionsPanel';
+
+describe('T-AUTH-003: PermissionsPanel', () => {
+  const onUpdateRole = vi.fn();
+  const onInvite = vi.fn();
+  const onRemove = vi.fn();
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const members: ProjectMember[] = [
+    { userId: 'u1', name: 'Alice', email: 'alice@example.com', role: 'owner' },
+    { userId: 'u2', name: 'Bob', email: 'bob@example.com', role: 'editor' },
+    { userId: 'u3', name: 'Carol', email: 'carol@example.com', role: 'viewer' },
+  ];
+
+  it('renders Permissions header', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    expect(screen.getByText(/permissions|team members/i)).toBeInTheDocument();
+  });
+
+  it('shows member names', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Carol')).toBeInTheDocument();
+  });
+
+  it('shows role for each member', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    expect(screen.getAllByText(/owner/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/editor/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/viewer/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows role selector for non-owner members', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    const selects = screen.getAllByRole('combobox');
+    expect(selects.length).toBeGreaterThan(0);
+  });
+
+  it('calls onUpdateRole when role changed', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[0]!, { target: { value: 'viewer' } });
+    expect(onUpdateRole).toHaveBeenCalled();
+  });
+
+  it('shows Remove button for non-owner members', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    expect(screen.getAllByRole('button', { name: /remove/i }).length).toBeGreaterThan(0);
+  });
+
+  it('calls onRemove when Remove clicked', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /remove/i })[0]!);
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('shows invite email input', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+  });
+
+  it('calls onInvite with email and role', () => {
+    render(<PermissionsPanel members={members} onUpdateRole={onUpdateRole} onInvite={onInvite} onRemove={onRemove} />);
+    fireEvent.change(screen.getByPlaceholderText(/email/i), { target: { value: 'new@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /invite/i }));
+    expect(onInvite).toHaveBeenCalledWith(expect.objectContaining({ email: 'new@example.com' }));
+  });
+});

--- a/packages/app/src/components/PermissionsPanel.tsx
+++ b/packages/app/src/components/PermissionsPanel.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+
+export type ProjectRole = 'owner' | 'editor' | 'viewer';
+
+export interface ProjectMember {
+  userId: string;
+  name: string;
+  email: string;
+  role: ProjectRole;
+}
+
+interface PermissionsPanelProps {
+  members: ProjectMember[];
+  onUpdateRole: (userId: string, role: ProjectRole) => void;
+  onInvite: (params: { email: string; role: ProjectRole }) => void;
+  onRemove: (userId: string) => void;
+}
+
+const ROLES: ProjectRole[] = ['owner', 'editor', 'viewer'];
+
+export function PermissionsPanel({ members, onUpdateRole, onInvite, onRemove }: PermissionsPanelProps) {
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<ProjectRole>('viewer');
+
+  const handleInvite = () => {
+    const email = inviteEmail.trim();
+    if (!email) return;
+    onInvite({ email, role: inviteRole });
+    setInviteEmail('');
+  };
+
+  return (
+    <div className="permissions-panel">
+      <div className="panel-header">
+        <span className="panel-title">Team Members &amp; Permissions</span>
+      </div>
+
+      <div className="members-list">
+        {members.map((m) => (
+          <div key={m.userId} className="member-row">
+            <div className="member-info">
+              <span className="member-name">{m.name}</span>
+              <span className="member-email">{m.email}</span>
+            </div>
+            {m.role === 'owner' ? (
+              <span className="role-badge owner">Owner</span>
+            ) : (
+              <>
+                <select
+                  aria-label={`Role for ${m.name}`}
+                  value={m.role}
+                  onChange={(e) => onUpdateRole(m.userId, e.target.value as ProjectRole)}
+                  className="role-select"
+                >
+                  {ROLES.filter((r) => r !== 'owner').map((r) => (
+                    <option key={r} value={r}>
+                      {r.charAt(0).toUpperCase() + r.slice(1)}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  aria-label={`Remove ${m.name}`}
+                  className="btn-remove"
+                  onClick={() => onRemove(m.userId)}
+                >
+                  Remove
+                </button>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="invite-row">
+        <input
+          type="email"
+          placeholder="Invite by email…"
+          value={inviteEmail}
+          onChange={(e) => setInviteEmail(e.target.value)}
+          className="invite-email-input"
+        />
+        <select
+          aria-label="Role for invite"
+          value={inviteRole}
+          onChange={(e) => setInviteRole(e.target.value as ProjectRole)}
+          className="invite-role-select"
+        >
+          <option value="editor">Editor</option>
+          <option value="viewer">Viewer</option>
+        </select>
+        <button
+          aria-label="Invite member"
+          className="btn-invite"
+          onClick={handleInvite}
+        >
+          Invite
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `PermissionsPanel` component for owner/editor/viewer role management
- Invite by email with role selection
- Remove members, change roles for non-owners

## Test plan
- [x] 9 unit tests passing
- [x] TypeScript strict mode passes

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)