### PR TITLE
feat(app): T-SYNC-012 sync status bar

### DIFF
--- a/packages/app/src/components/SyncStatusBar.test.tsx
+++ b/packages/app/src/components/SyncStatusBar.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SyncStatusBar } from './SyncStatusBar';
+
+describe('T-SYNC-012: SyncStatusBar', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('shows connected status', () => {
+    render(<SyncStatusBar status="connected" pendingOps={0} lastSynced={Date.now()} />);
+    expect(screen.getByText(/connected/i)).toBeInTheDocument();
+  });
+
+  it('shows syncing status', () => {
+    render(<SyncStatusBar status="syncing" pendingOps={3} lastSynced={null} />);
+    expect(screen.getByText(/sync/i)).toBeInTheDocument();
+  });
+
+  it('shows offline status', () => {
+    render(<SyncStatusBar status="offline" pendingOps={5} lastSynced={null} />);
+    expect(screen.getByText(/offline/i)).toBeInTheDocument();
+  });
+
+  it('shows error status', () => {
+    render(<SyncStatusBar status="error" pendingOps={0} lastSynced={null} errorMessage="Connection refused" />);
+    expect(screen.getAllByText(/error|connection refused/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows pending operations count when > 0', () => {
+    render(<SyncStatusBar status="syncing" pendingOps={7} lastSynced={null} />);
+    expect(screen.getByText(/7/)).toBeInTheDocument();
+  });
+
+  it('shows last synced time when connected', () => {
+    const ts = Date.now() - 60000;
+    render(<SyncStatusBar status="connected" pendingOps={0} lastSynced={ts} />);
+    expect(screen.getAllByText(/sync|saved|ago/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders status indicator element', () => {
+    render(<SyncStatusBar status="connected" pendingOps={0} lastSynced={null} />);
+    expect(document.querySelector('.sync-status-bar')).toBeInTheDocument();
+  });
+
+  it('renders status dot with correct class', () => {
+    render(<SyncStatusBar status="offline" pendingOps={0} lastSynced={null} />);
+    expect(document.querySelector('.status-dot')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/SyncStatusBar.tsx
+++ b/packages/app/src/components/SyncStatusBar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export type SyncStatus = 'connected' | 'syncing' | 'offline' | 'error';
+
+interface SyncStatusBarProps {
+  status: SyncStatus;
+  pendingOps: number;
+  lastSynced: number | null;
+  errorMessage?: string;
+}
+
+function formatRelativeTime(ts: number): string {
+  const diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  return `${Math.floor(diff / 3600)}h ago`;
+}
+
+const STATUS_LABELS: Record<SyncStatus, string> = {
+  connected: 'Connected',
+  syncing: 'Syncing…',
+  offline: 'Offline',
+  error: 'Sync Error',
+};
+
+export function SyncStatusBar({ status, pendingOps, lastSynced, errorMessage }: SyncStatusBarProps) {
+  return (
+    <div className={`sync-status-bar sync-${status}`} role="status" aria-live="polite">
+      <span className={`status-dot status-dot-${status}`} aria-hidden="true" />
+      <span className="status-label">{STATUS_LABELS[status]}</span>
+
+      {status === 'error' && errorMessage && (
+        <span className="status-error-msg"> — {errorMessage}</span>
+      )}
+
+      {pendingOps > 0 && (
+        <span className="pending-ops">{pendingOps} pending</span>
+      )}
+
+      {status === 'connected' && lastSynced !== null && (
+        <span className="last-synced">Last synced {formatRelativeTime(lastSynced)}</span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SyncStatusBar` component showing CRDT sync connection state
- States: connected, syncing, offline, error with pending ops count and last-synced time

## Test plan
- [x] 8 unit tests passing
- [x] TypeScript strict mode passes

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)