### PR TITLE
feat(app): T-RENDER-001 PBR render panel

### DIFF
--- a/packages/app/src/components/RenderPanel.test.tsx
+++ b/packages/app/src/components/RenderPanel.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { RenderPanel } from './RenderPanel';
+
+describe('T-RENDER-001: RenderPanel', () => {
+  const onChange = vi.fn();
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const defaultSettings = {
+    ambientOcclusion: true,
+    shadows: true,
+    shadowIntensity: 0.5,
+    exposure: 1.0,
+    toneMapping: 'aces' as const,
+    environmentMap: 'studio' as const,
+    groundReflections: false,
+    bloomEnabled: false,
+    bloomStrength: 0.3,
+  };
+
+  it('renders Render Settings header', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    expect(screen.getByText(/render settings/i)).toBeInTheDocument();
+  });
+
+  it('shows ambient occlusion toggle', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    expect(screen.getByLabelText(/ambient occlusion/i)).toBeInTheDocument();
+  });
+
+  it('shows shadows toggle', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    expect(screen.getByLabelText(/shadows/i)).toBeInTheDocument();
+  });
+
+  it('shows exposure slider', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    expect(screen.getByLabelText(/exposure/i)).toBeInTheDocument();
+  });
+
+  it('shows tone mapping select', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    expect(screen.getByLabelText(/tone mapping/i)).toBeInTheDocument();
+  });
+
+  it('shows environment map select', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    expect(screen.getByLabelText(/environment/i)).toBeInTheDocument();
+  });
+
+  it('calls onChange when AO toggled', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText(/ambient occlusion/i));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ ambientOcclusion: false }));
+  });
+
+  it('calls onChange when exposure changed', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText(/exposure/i), { target: { value: '1.5' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ exposure: 1.5 }));
+  });
+
+  it('shows bloom toggle', () => {
+    render(<RenderPanel settings={defaultSettings} onChange={onChange} />);
+    expect(screen.getByLabelText(/bloom/i)).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/RenderPanel.tsx
+++ b/packages/app/src/components/RenderPanel.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+
+type ToneMapping = 'linear' | 'aces' | 'reinhard' | 'cineon';
+type EnvironmentMap = 'studio' | 'outdoor' | 'sunset' | 'night' | 'none';
+
+export interface RenderSettings {
+  ambientOcclusion: boolean;
+  shadows: boolean;
+  shadowIntensity: number;
+  exposure: number;
+  toneMapping: ToneMapping;
+  environmentMap: EnvironmentMap;
+  groundReflections: boolean;
+  bloomEnabled: boolean;
+  bloomStrength: number;
+}
+
+interface RenderPanelProps {
+  settings: RenderSettings;
+  onChange: (settings: RenderSettings) => void;
+}
+
+export function RenderPanel({ settings, onChange }: RenderPanelProps) {
+  const update = (patch: Partial<RenderSettings>) => onChange({ ...settings, ...patch });
+
+  return (
+    <div className="render-panel">
+      <div className="panel-header">
+        <span className="panel-title">Render Settings</span>
+      </div>
+
+      <div className="render-section">
+        <h4>Lighting</h4>
+
+        <div className="render-field">
+          <label htmlFor="ao-toggle">Ambient Occlusion</label>
+          <input
+            id="ao-toggle"
+            type="checkbox"
+            checked={settings.ambientOcclusion}
+            onChange={(e) => update({ ambientOcclusion: e.target.checked })}
+          />
+        </div>
+
+        <div className="render-field">
+          <label htmlFor="shadows-toggle">Shadows</label>
+          <input
+            id="shadows-toggle"
+            type="checkbox"
+            checked={settings.shadows}
+            onChange={(e) => update({ shadows: e.target.checked })}
+          />
+        </div>
+
+        {settings.shadows && (
+          <div className="render-field">
+            <label htmlFor="shadow-intensity">Shadow Intensity</label>
+            <input
+              id="shadow-intensity"
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={settings.shadowIntensity}
+              onChange={(e) => update({ shadowIntensity: parseFloat(e.target.value) })}
+            />
+            <span>{settings.shadowIntensity.toFixed(2)}</span>
+          </div>
+        )}
+
+        <div className="render-field">
+          <label htmlFor="exposure-range">Exposure</label>
+          <input
+            id="exposure-range"
+            type="range"
+            min={0.1}
+            max={3}
+            step={0.1}
+            value={settings.exposure}
+            onChange={(e) => update({ exposure: parseFloat(e.target.value) })}
+          />
+          <span>{settings.exposure.toFixed(1)}</span>
+        </div>
+
+        <div className="render-field">
+          <label htmlFor="tone-mapping-select">Tone Mapping</label>
+          <select
+            id="tone-mapping-select"
+            value={settings.toneMapping}
+            onChange={(e) => update({ toneMapping: e.target.value as ToneMapping })}
+          >
+            <option value="linear">Linear</option>
+            <option value="aces">ACES Filmic</option>
+            <option value="reinhard">Reinhard</option>
+            <option value="cineon">Cineon</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="render-section">
+        <h4>Environment</h4>
+
+        <div className="render-field">
+          <label htmlFor="env-map-select">Environment Map</label>
+          <select
+            id="env-map-select"
+            value={settings.environmentMap}
+            onChange={(e) => update({ environmentMap: e.target.value as EnvironmentMap })}
+          >
+            <option value="studio">Studio</option>
+            <option value="outdoor">Outdoor</option>
+            <option value="sunset">Sunset</option>
+            <option value="night">Night</option>
+            <option value="none">None</option>
+          </select>
+        </div>
+
+        <div className="render-field">
+          <label htmlFor="ground-reflections-toggle">Ground Reflections</label>
+          <input
+            id="ground-reflections-toggle"
+            type="checkbox"
+            checked={settings.groundReflections}
+            onChange={(e) => update({ groundReflections: e.target.checked })}
+          />
+        </div>
+      </div>
+
+      <div className="render-section">
+        <h4>Post-Processing</h4>
+
+        <div className="render-field">
+          <label htmlFor="bloom-toggle">Bloom</label>
+          <input
+            id="bloom-toggle"
+            type="checkbox"
+            checked={settings.bloomEnabled}
+            onChange={(e) => update({ bloomEnabled: e.target.checked })}
+          />
+        </div>
+
+        {settings.bloomEnabled && (
+          <div className="render-field">
+            <label htmlFor="bloom-strength">Bloom Strength</label>
+            <input
+              id="bloom-strength"
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={settings.bloomStrength}
+              onChange={(e) => update({ bloomStrength: parseFloat(e.target.value) })}
+            />
+            <span>{settings.bloomStrength.toFixed(2)}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `RenderPanel` component for real-time PBR renderer controls
- Controls: ambient occlusion, shadows, shadow intensity, exposure, tone mapping, environment map, ground reflections, bloom

## Test plan
- [x] 9 unit tests passing
- [x] TypeScript strict mode passes

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)