### PR TITLE
feat(app): T-COST-001 cost intelligence panel

### DIFF
--- a/packages/app/src/components/CostPanel.test.tsx
+++ b/packages/app/src/components/CostPanel.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { CostPanel, type CostItem } from './CostPanel';
+
+describe('T-COST-001: CostPanel', () => {
+  const onExport = vi.fn();
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const items: CostItem[] = [
+    { id: 'c1', elementType: 'wall', description: 'External Wall 200mm', quantity: 50, unit: 'm²', unitRate: 120, total: 6000 },
+    { id: 'c2', elementType: 'slab', description: 'Ground Floor Slab', quantity: 80, unit: 'm²', unitRate: 95, total: 7600 },
+    { id: 'c3', elementType: 'door', description: 'Internal Door', quantity: 8, unit: 'nr', unitRate: 450, total: 3600 },
+  ];
+
+  it('renders Cost Estimate header', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getByText(/cost estimate/i)).toBeInTheDocument();
+  });
+
+  it('shows element description', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getByText('External Wall 200mm')).toBeInTheDocument();
+  });
+
+  it('shows quantity and unit', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getAllByText(/m²|nr/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows unit rate', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getAllByText(/120|95|450/).length).toBeGreaterThan(0);
+  });
+
+  it('shows total for each item', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getAllByText(/6,000|6000/).length).toBeGreaterThan(0);
+  });
+
+  it('shows grand total', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getAllByText(/17,200|total/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Export button', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
+  });
+
+  it('calls onExport when Export clicked', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(onExport).toHaveBeenCalledWith(items);
+  });
+
+  it('shows empty state when no items', () => {
+    render(<CostPanel items={[]} onExport={onExport} />);
+    expect(screen.getByText(/no cost items|empty/i)).toBeInTheDocument();
+  });
+
+  it('shows element type grouping', () => {
+    render(<CostPanel items={items} onExport={onExport} />);
+    expect(screen.getAllByText(/wall|slab|door/i).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/components/CostPanel.tsx
+++ b/packages/app/src/components/CostPanel.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+export interface CostItem {
+  id: string;
+  elementType: string;
+  description: string;
+  quantity: number;
+  unit: string;
+  unitRate: number;
+  total: number;
+}
+
+interface CostPanelProps {
+  items: CostItem[];
+  onExport: (items: CostItem[]) => void;
+  currency?: string;
+}
+
+function formatCurrency(value: number, currency = '$'): string {
+  return `${currency}${value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+export function CostPanel({ items, onExport, currency = '$' }: CostPanelProps) {
+  const grandTotal = items.reduce((sum, item) => sum + item.total, 0);
+
+  return (
+    <div className="cost-panel">
+      <div className="panel-header">
+        <span className="panel-title">Cost Estimate</span>
+        <button
+          aria-label="Export cost estimate"
+          className="btn-export"
+          onClick={() => onExport(items)}
+          disabled={items.length === 0}
+        >
+          Export
+        </button>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="cost-empty">No cost items. Add elements to generate an estimate.</div>
+      ) : (
+        <>
+          <table className="cost-table">
+            <thead>
+              <tr>
+                <th>Description</th>
+                <th>Type</th>
+                <th>Qty</th>
+                <th>Unit</th>
+                <th>Rate</th>
+                <th>Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr key={item.id} className="cost-row">
+                  <td className="cost-desc">{item.description}</td>
+                  <td className="cost-type">{item.elementType}</td>
+                  <td className="cost-qty">{item.quantity}</td>
+                  <td className="cost-unit">{item.unit}</td>
+                  <td className="cost-rate">{formatCurrency(item.unitRate, currency)}</td>
+                  <td className="cost-total">{formatCurrency(item.total, currency)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="cost-grand-total">
+                <td colSpan={5}><strong>Total</strong></td>
+                <td><strong>{formatCurrency(grandTotal, currency)}</strong></td>
+              </tr>
+            </tfoot>
+          </table>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `CostPanel` component with elemental cost estimate table
- Shows quantity, unit, unit rate, and total per element type
- Grand total sum and Export callback

## Test plan
- [x] 10 unit tests passing
- [x] TypeScript strict mode passes

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)