### PR TITLE
feat(app): T-BCF-001 BCF 2.1 import/export panel

### DIFF
--- a/packages/app/src/components/BCFPanel.test.tsx
+++ b/packages/app/src/components/BCFPanel.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { BCFPanel, type BCFTopic } from './BCFPanel';
+
+describe('T-BCF-001: BCFPanel', () => {
+  const onImport = vi.fn();
+  const onExport = vi.fn();
+  const onSelectTopic = vi.fn();
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const topics: BCFTopic[] = [
+    {
+      guid: 't1',
+      title: 'Wall clash at grid A1',
+      status: 'open',
+      priority: 'high',
+      creationDate: '2024-01-15',
+      assignedTo: 'alice@example.com',
+      description: 'Structural wall clashing with ductwork.',
+    },
+    {
+      guid: 't2',
+      title: 'Window sill height',
+      status: 'resolved',
+      priority: 'normal',
+      creationDate: '2024-01-10',
+      assignedTo: 'bob@example.com',
+      description: 'Window sill is 10mm too low per code.',
+    },
+  ];
+
+  it('renders BCF Issues header', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getByText(/bcf issues/i)).toBeInTheDocument();
+  });
+
+  it('shows topic titles', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getByText('Wall clash at grid A1')).toBeInTheDocument();
+  });
+
+  it('shows status badges', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getAllByText(/open|resolved/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows priority labels', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getAllByText(/high|normal/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Import BCF button', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getByRole('button', { name: /import bcf/i })).toBeInTheDocument();
+  });
+
+  it('shows Export BCF button', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getByRole('button', { name: /export bcf/i })).toBeInTheDocument();
+  });
+
+  it('calls onExport when Export BCF clicked', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    fireEvent.click(screen.getByRole('button', { name: /export bcf/i }));
+    expect(onExport).toHaveBeenCalledWith(topics);
+  });
+
+  it('calls onSelectTopic when topic clicked', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    fireEvent.click(screen.getByText('Wall clash at grid A1'));
+    expect(onSelectTopic).toHaveBeenCalledWith(topics[0]);
+  });
+
+  it('shows assigned to email', () => {
+    render(<BCFPanel topics={topics} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getAllByText(/alice|bob/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows empty state when no topics', () => {
+    render(<BCFPanel topics={[]} onImport={onImport} onExport={onExport} onSelectTopic={onSelectTopic} />);
+    expect(screen.getByText(/no bcf issues/i)).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/BCFPanel.tsx
+++ b/packages/app/src/components/BCFPanel.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+export type BCFStatus = 'open' | 'in-progress' | 'resolved' | 'closed';
+export type BCFPriority = 'critical' | 'high' | 'normal' | 'low';
+
+export interface BCFTopic {
+  guid: string;
+  title: string;
+  status: BCFStatus;
+  priority: BCFPriority;
+  creationDate: string;
+  assignedTo?: string;
+  description?: string;
+  viewpointUrl?: string;
+}
+
+interface BCFPanelProps {
+  topics: BCFTopic[];
+  onImport: (file: File) => void;
+  onExport: (topics: BCFTopic[]) => void;
+  onSelectTopic: (topic: BCFTopic) => void;
+}
+
+const STATUS_COLORS: Record<BCFStatus, string> = {
+  open: '#e74c3c',
+  'in-progress': '#f39c12',
+  resolved: '#27ae60',
+  closed: '#95a5a6',
+};
+
+const PRIORITY_LABELS: Record<BCFPriority, string> = {
+  critical: 'Critical',
+  high: 'High',
+  normal: 'Normal',
+  low: 'Low',
+};
+
+export function BCFPanel({ topics, onImport, onExport, onSelectTopic }: BCFPanelProps) {
+  const handleImportClick = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.bcf,.bcfzip';
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) onImport(file);
+    };
+    input.click();
+  };
+
+  return (
+    <div className="bcf-panel">
+      <div className="panel-header">
+        <span className="panel-title">BCF Issues</span>
+        <div className="bcf-actions">
+          <button
+            aria-label="Import BCF"
+            className="btn-import-bcf"
+            onClick={handleImportClick}
+          >
+            Import BCF
+          </button>
+          <button
+            aria-label="Export BCF"
+            className="btn-export-bcf"
+            onClick={() => onExport(topics)}
+          >
+            Export BCF
+          </button>
+        </div>
+      </div>
+
+      {topics.length === 0 ? (
+        <div className="bcf-empty">No BCF issues. Import a .bcf file or create issues from the model.</div>
+      ) : (
+        <div className="bcf-topics">
+          {topics.map((topic) => (
+            <div
+              key={topic.guid}
+              className="bcf-topic"
+              onClick={() => onSelectTopic(topic)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => { if (e.key === 'Enter') onSelectTopic(topic); }}
+            >
+              <div className="topic-header">
+                <span
+                  className="topic-status"
+                  style={{ color: STATUS_COLORS[topic.status] }}
+                >
+                  {topic.status}
+                </span>
+                <span className="topic-priority">{PRIORITY_LABELS[topic.priority]}</span>
+              </div>
+              <div className="topic-title">{topic.title}</div>
+              {topic.assignedTo && (
+                <div className="topic-assigned">{topic.assignedTo}</div>
+              )}
+              <div className="topic-date">{topic.creationDate}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `BCFPanel` for BCF 2.1 issue coordination with Revit/Navisworks/BIMcollab
- Shows topics with status, priority, assigned-to, and creation date
- Import BCF (.bcf/.bcfzip) via file picker, Export all topics callback

## Test plan
- [x] 10 unit tests passing
- [x] TypeScript strict mode passes

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)