### PR TITLE
feat(app): T-COST-002 carbon calculator panel

### DIFF
--- a/packages/app/src/components/CarbonPanel.test.tsx
+++ b/packages/app/src/components/CarbonPanel.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { CarbonPanel, type CarbonEntry } from './CarbonPanel';
+
+describe('T-COST-002: CarbonPanel', () => {
+  const onExport = vi.fn();
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const entries: CarbonEntry[] = [
+    { id: 'e1', material: 'Concrete C30', quantity: 50, unit: 'm³', kgCO2ePerUnit: 300, totalKgCO2e: 15000, stage: 'A1-A3' },
+    { id: 'e2', material: 'Structural Steel', quantity: 2, unit: 't', kgCO2ePerUnit: 1600, totalKgCO2e: 3200, stage: 'A1-A3' },
+    { id: 'e3', material: 'Timber Frame', quantity: 10, unit: 'm³', kgCO2ePerUnit: 50, totalKgCO2e: 500, stage: 'A1-A3' },
+  ];
+
+  it('renders Carbon Calculator header', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    expect(screen.getByText(/carbon calculator/i)).toBeInTheDocument();
+  });
+
+  it('shows material names', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    expect(screen.getByText('Concrete C30')).toBeInTheDocument();
+    expect(screen.getByText('Structural Steel')).toBeInTheDocument();
+  });
+
+  it('shows kgCO2e values', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    expect(screen.getAllByText(/kgco2e|kg co2/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows total embodied carbon', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    expect(screen.getAllByText(/18,700|total/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows lifecycle stage labels', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    expect(screen.getAllByText(/A1-A3/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Export button', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
+  });
+
+  it('calls onExport when Export clicked', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(onExport).toHaveBeenCalledWith(entries);
+  });
+
+  it('shows empty state when no entries', () => {
+    render(<CarbonPanel entries={[]} onExport={onExport} />);
+    expect(screen.getByText(/no carbon data|empty/i)).toBeInTheDocument();
+  });
+
+  it('shows carbon intensity metric', () => {
+    render(<CarbonPanel entries={entries} onExport={onExport} />);
+    expect(screen.getAllByText(/kgco2e|intensity|total/i).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/components/CarbonPanel.tsx
+++ b/packages/app/src/components/CarbonPanel.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+export type LifecycleStage = 'A1-A3' | 'A4' | 'A5' | 'B1-B7' | 'C1-C4' | 'D';
+
+export interface CarbonEntry {
+  id: string;
+  material: string;
+  quantity: number;
+  unit: string;
+  kgCO2ePerUnit: number;
+  totalKgCO2e: number;
+  stage: LifecycleStage;
+}
+
+interface CarbonPanelProps {
+  entries: CarbonEntry[];
+  onExport: (entries: CarbonEntry[]) => void;
+}
+
+function formatCarbon(value: number): string {
+  return value.toLocaleString('en-US', { maximumFractionDigits: 0 });
+}
+
+export function CarbonPanel({ entries, onExport }: CarbonPanelProps) {
+  const totalKgCO2e = entries.reduce((sum, e) => sum + e.totalKgCO2e, 0);
+
+  return (
+    <div className="carbon-panel">
+      <div className="panel-header">
+        <span className="panel-title">Carbon Calculator</span>
+        <button
+          aria-label="Export carbon report"
+          className="btn-export"
+          onClick={() => onExport(entries)}
+          disabled={entries.length === 0}
+        >
+          Export
+        </button>
+      </div>
+
+      {entries.length === 0 ? (
+        <div className="carbon-empty">No carbon data. Add materials with carbon factors to calculate.</div>
+      ) : (
+        <>
+          <div className="carbon-summary">
+            <span className="carbon-total-label">Total Embodied Carbon</span>
+            <span className="carbon-total-value">
+              {formatCarbon(totalKgCO2e)} kgCO2e
+            </span>
+          </div>
+
+          <table className="carbon-table">
+            <thead>
+              <tr>
+                <th>Material</th>
+                <th>Qty</th>
+                <th>Unit</th>
+                <th>kgCO2e/unit</th>
+                <th>Total kgCO2e</th>
+                <th>Stage</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <tr key={entry.id} className="carbon-row">
+                  <td>{entry.material}</td>
+                  <td>{entry.quantity}</td>
+                  <td>{entry.unit}</td>
+                  <td>{entry.kgCO2ePerUnit}</td>
+                  <td>{formatCarbon(entry.totalKgCO2e)}</td>
+                  <td className="stage-badge">{entry.stage}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={4}><strong>Total</strong></td>
+                <td colSpan={2}><strong>{formatCarbon(totalKgCO2e)} kgCO2e</strong></td>
+              </tr>
+            </tfoot>
+          </table>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `CarbonPanel` for embodied carbon calculation from material quantities
- Shows kgCO2e per unit, total per material, grand total, and lifecycle stages (A1-A3 etc.)

## Test plan
- [x] 9 unit tests passing
- [x] TypeScript strict mode passes

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)