### PR TITLE
feat(app): T-API-001 API key management panel

### DIFF
--- a/packages/app/src/components/APIKeyPanel.test.tsx
+++ b/packages/app/src/components/APIKeyPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { APIKeyPanel, type APIKey } from './APIKeyPanel';
+
+describe('T-API-001: APIKeyPanel', () => {
+  const onCreate = vi.fn();
+  const onRevoke = vi.fn();
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const keys: APIKey[] = [
+    { id: 'k1', name: 'CI/CD Pipeline', prefix: 'oc_live_xxxx', scopes: ['read', 'write'], createdAt: '2024-01-10', lastUsed: '2024-01-20' },
+    { id: 'k2', name: 'Read-only Analytics', prefix: 'oc_live_yyyy', scopes: ['read'], createdAt: '2024-01-05', lastUsed: null },
+  ];
+
+  it('renders API Keys header', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    expect(screen.getByText(/api keys/i)).toBeInTheDocument();
+  });
+
+  it('shows key names', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    expect(screen.getByText('CI/CD Pipeline')).toBeInTheDocument();
+    expect(screen.getByText('Read-only Analytics')).toBeInTheDocument();
+  });
+
+  it('shows key prefixes (masked)', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    expect(screen.getAllByText(/oc_live/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows scopes for each key', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    expect(screen.getAllByText(/read|write/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Revoke button for each key', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    expect(screen.getAllByRole('button', { name: /revoke/i }).length).toBe(2);
+  });
+
+  it('calls onRevoke with key id when Revoke clicked', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /revoke/i })[0]!);
+    expect(onRevoke).toHaveBeenCalledWith('k1');
+  });
+
+  it('shows Create New Key button', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    expect(screen.getByRole('button', { name: /create.*key|new.*key/i })).toBeInTheDocument();
+  });
+
+  it('shows key name input when creating', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    fireEvent.click(screen.getByRole('button', { name: /create.*key|new.*key/i }));
+    expect(screen.getByPlaceholderText(/key name/i)).toBeInTheDocument();
+  });
+
+  it('calls onCreate with name and scopes', () => {
+    render(<APIKeyPanel keys={keys} onCreate={onCreate} onRevoke={onRevoke} />);
+    fireEvent.click(screen.getByRole('button', { name: /create.*key|new.*key/i }));
+    fireEvent.change(screen.getByPlaceholderText(/key name/i), { target: { value: 'My App' } });
+    fireEvent.click(screen.getByRole('button', { name: /generate key/i }));
+    expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'My App' }));
+  });
+});

--- a/packages/app/src/components/APIKeyPanel.tsx
+++ b/packages/app/src/components/APIKeyPanel.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+
+export type APIKeyScope = 'read' | 'write' | 'admin';
+
+export interface APIKey {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: APIKeyScope[];
+  createdAt: string;
+  lastUsed: string | null;
+}
+
+interface APIKeyPanelProps {
+  keys: APIKey[];
+  onCreate: (params: { name: string; scopes: APIKeyScope[] }) => void;
+  onRevoke: (keyId: string) => void;
+}
+
+export function APIKeyPanel({ keys, onCreate, onRevoke }: APIKeyPanelProps) {
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newScopes, setNewScopes] = useState<APIKeyScope[]>(['read']);
+
+  const toggleScope = (scope: APIKeyScope) => {
+    setNewScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]
+    );
+  };
+
+  const handleCreate = () => {
+    const name = newName.trim();
+    if (!name) return;
+    onCreate({ name, scopes: newScopes });
+    setCreating(false);
+    setNewName('');
+    setNewScopes(['read']);
+  };
+
+  return (
+    <div className="api-key-panel">
+      <div className="panel-header">
+        <span className="panel-title">API Keys</span>
+        <button
+          aria-label="Create new API key"
+          className="btn-create-key"
+          onClick={() => setCreating(!creating)}
+        >
+          + New API Key
+        </button>
+      </div>
+
+      {creating && (
+        <div className="create-key-form">
+          <input
+            type="text"
+            placeholder="Key name (e.g. CI/CD Pipeline)"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            className="key-name-input"
+          />
+          <div className="scope-checkboxes">
+            {(['read', 'write', 'admin'] as APIKeyScope[]).map((scope) => (
+              <label key={scope} className="scope-label">
+                <input
+                  type="checkbox"
+                  checked={newScopes.includes(scope)}
+                  onChange={() => toggleScope(scope)}
+                />
+                {scope}
+              </label>
+            ))}
+          </div>
+          <div className="create-actions">
+            <button
+              aria-label="Generate key"
+              className="btn-generate"
+              onClick={handleCreate}
+            >
+              Generate Key
+            </button>
+            <button onClick={() => setCreating(false)} className="btn-cancel">Cancel</button>
+          </div>
+        </div>
+      )}
+
+      <div className="api-keys-list">
+        {keys.map((key) => (
+          <div key={key.id} className="api-key-row">
+            <div className="key-info">
+              <span className="key-name">{key.name}</span>
+              <span className="key-prefix">{key.prefix}•••••••••••</span>
+              <span className="key-scopes">{key.scopes.join(', ')}</span>
+              <span className="key-meta">
+                Created {key.createdAt}
+                {key.lastUsed && ` · Last used ${key.lastUsed}`}
+              </span>
+            </div>
+            <button
+              aria-label={`Revoke ${key.name}`}
+              className="btn-revoke"
+              onClick={() => onRevoke(key.id)}
+            >
+              Revoke
+            </button>
+          </div>
+        ))}
+        {keys.length === 0 && <div className="keys-empty">No API keys yet.</div>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `APIKeyPanel` for managing REST API keys (create, revoke, view scopes)
- Keys show masked prefix, scopes (read/write/admin), creation date, last used date

## Test plan
- [x] 9 unit tests passing
- [x] TypeScript strict mode passes

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)