### PR TITLE
feat(app): T-MKTPL-001 component marketplace panel

### DIFF
--- a/packages/app/src/components/MarketplacePanel.test.tsx
+++ b/packages/app/src/components/MarketplacePanel.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MarketplacePanel, type MarketplaceItem } from './MarketplacePanel';
+
+describe('T-MKTPL-001: MarketplacePanel', () => {
+  const onInstall = vi.fn();
+  const onPublish = vi.fn();
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const items: MarketplaceItem[] = [
+    { id: 'pkg-1', name: 'Steel Column Library', author: 'StructuralCo', description: 'Standard steel column profiles.', version: '1.2.0', category: 'Structural', downloads: 1200, installed: false },
+    { id: 'pkg-2', name: 'Door Families Pack', author: 'DoorWorks', description: 'Over 50 parametric door families.', version: '2.0.1', category: 'Architectural', downloads: 890, installed: true },
+    { id: 'pkg-3', name: 'MEP Symbols', author: 'MEPLib', description: 'Complete set of MEP symbols.', version: '1.0.0', category: 'MEP', downloads: 500, installed: false },
+  ];
+
+  it('renders Marketplace header', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    expect(screen.getByText(/marketplace/i)).toBeInTheDocument();
+  });
+
+  it('shows component names', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    expect(screen.getByText('Steel Column Library')).toBeInTheDocument();
+    expect(screen.getByText('Door Families Pack')).toBeInTheDocument();
+  });
+
+  it('shows Install button for uninstalled items', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    expect(screen.getAllByRole('button', { name: /install/i }).length).toBeGreaterThan(0);
+  });
+
+  it('shows Installed badge for installed items', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    expect(screen.getByText(/installed/i)).toBeInTheDocument();
+  });
+
+  it('calls onInstall with item when Install clicked', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /install/i })[0]!);
+    expect(onInstall).toHaveBeenCalledWith(expect.objectContaining({ id: expect.any(String) }));
+  });
+
+  it('shows search input', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+  });
+
+  it('filters items by search', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'column' } });
+    expect(screen.getByText('Steel Column Library')).toBeInTheDocument();
+    expect(screen.queryByText('Door Families Pack')).not.toBeInTheDocument();
+  });
+
+  it('shows download count', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    expect(screen.getAllByText(/1,200|1200|downloads/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Publish button', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    expect(screen.getByRole('button', { name: /publish/i })).toBeInTheDocument();
+  });
+
+  it('calls onPublish when Publish clicked', () => {
+    render(<MarketplacePanel items={items} onInstall={onInstall} onPublish={onPublish} />);
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    expect(onPublish).toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/components/MarketplacePanel.tsx
+++ b/packages/app/src/components/MarketplacePanel.tsx
@@ -1,0 +1,81 @@
+import React, { useState, useMemo } from 'react';
+
+export interface MarketplaceItem {
+  id: string;
+  name: string;
+  author: string;
+  description: string;
+  version: string;
+  category: string;
+  downloads: number;
+  installed: boolean;
+}
+
+interface MarketplacePanelProps {
+  items: MarketplaceItem[];
+  onInstall: (item: MarketplaceItem) => void;
+  onPublish: () => void;
+}
+
+export function MarketplacePanel({ items, onInstall, onPublish }: MarketplacePanelProps) {
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return !q ? items : items.filter((item) =>
+      item.name.toLowerCase().includes(q) ||
+      item.description.toLowerCase().includes(q) ||
+      item.category.toLowerCase().includes(q)
+    );
+  }, [items, search]);
+
+  return (
+    <div className="marketplace-panel">
+      <div className="panel-header">
+        <span className="panel-title">Marketplace</span>
+        <button
+          aria-label="Publish component"
+          className="btn-publish"
+          onClick={onPublish}
+        >
+          Publish
+        </button>
+      </div>
+
+      <input
+        type="text"
+        placeholder="Search components…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="marketplace-search"
+      />
+
+      <div className="marketplace-list">
+        {filtered.map((item) => (
+          <div key={item.id} className="marketplace-item">
+            <div className="item-info">
+              <span className="item-name">{item.name}</span>
+              <span className="item-author">by {item.author}</span>
+              <span className="item-desc">{item.description}</span>
+              <span className="item-meta">
+                v{item.version} · {item.category} · {item.downloads.toLocaleString('en-US')} downloads
+              </span>
+            </div>
+            {item.installed ? (
+              <span className="installed-badge">Installed</span>
+            ) : (
+              <button
+                aria-label={`Install ${item.name}`}
+                className="btn-install"
+                onClick={() => onInstall(item)}
+              >
+                Install
+              </button>
+            )}
+          </div>
+        ))}
+        {filtered.length === 0 && <div className="marketplace-empty">No components found.</div>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `MarketplacePanel` for browsing/installing/publishing parametric component families
- Search/filter, install button, installed badge, download count, author info

## Test plan
- [x] 10 unit tests passing
- [x] TypeScript strict mode passes

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)