### PR TITLE
feat(app): T-AUTH-001 SSO settings panel (SAML/OIDC)

### DIFF
--- a/packages/app/src/components/SSOSettingsPanel.test.tsx
+++ b/packages/app/src/components/SSOSettingsPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SSOSettingsPanel } from './SSOSettingsPanel';
+
+describe('T-AUTH-001: SSOSettingsPanel', () => {
+  const onSave = vi.fn();
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const defaultConfig = {
+    enabled: false,
+    provider: 'saml' as const,
+    entityId: '',
+    ssoUrl: '',
+    certificate: '',
+    oidcClientId: '',
+    oidcClientSecret: '',
+    oidcDiscoveryUrl: '',
+  };
+
+  it('renders SSO Settings header', () => {
+    render(<SSOSettingsPanel config={defaultConfig} onSave={onSave} />);
+    expect(screen.getByText(/sso settings|single sign.on/i)).toBeInTheDocument();
+  });
+
+  it('shows SSO enabled toggle', () => {
+    render(<SSOSettingsPanel config={defaultConfig} onSave={onSave} />);
+    expect(screen.getByLabelText(/enable sso/i)).toBeInTheDocument();
+  });
+
+  it('shows provider selection (SAML, OIDC)', () => {
+    render(<SSOSettingsPanel config={defaultConfig} onSave={onSave} />);
+    expect(screen.getByLabelText(/provider/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/saml|oidc/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows SAML fields when provider is SAML', () => {
+    render(<SSOSettingsPanel config={{ ...defaultConfig, enabled: true, provider: 'saml' }} onSave={onSave} />);
+    expect(screen.getByLabelText(/entity id/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sso url/i)).toBeInTheDocument();
+  });
+
+  it('shows OIDC fields when provider is OIDC', () => {
+    render(<SSOSettingsPanel config={{ ...defaultConfig, enabled: true, provider: 'oidc' }} onSave={onSave} />);
+    expect(screen.getByLabelText(/client id/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/discovery url/i)).toBeInTheDocument();
+  });
+
+  it('shows Save button', () => {
+    render(<SSOSettingsPanel config={defaultConfig} onSave={onSave} />);
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('calls onSave with config when Save clicked', () => {
+    render(<SSOSettingsPanel config={defaultConfig} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ provider: 'saml' }));
+  });
+
+  it('updates entity ID field', () => {
+    render(<SSOSettingsPanel config={{ ...defaultConfig, enabled: true, provider: 'saml' }} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText(/entity id/i), { target: { value: 'https://idp.example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'https://idp.example.com' }));
+  });
+});

--- a/packages/app/src/components/SSOSettingsPanel.tsx
+++ b/packages/app/src/components/SSOSettingsPanel.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+
+type SSOProvider = 'saml' | 'oidc';
+
+export interface SSOConfig {
+  enabled: boolean;
+  provider: SSOProvider;
+  entityId: string;
+  ssoUrl: string;
+  certificate: string;
+  oidcClientId: string;
+  oidcClientSecret: string;
+  oidcDiscoveryUrl: string;
+}
+
+interface SSOSettingsPanelProps {
+  config: SSOConfig;
+  onSave: (config: SSOConfig) => void;
+}
+
+export function SSOSettingsPanel({ config: initialConfig, onSave }: SSOSettingsPanelProps) {
+  const [config, setConfig] = useState<SSOConfig>(initialConfig);
+
+  const update = (patch: Partial<SSOConfig>) => setConfig((prev) => ({ ...prev, ...patch }));
+
+  return (
+    <div className="sso-settings-panel">
+      <div className="panel-header">
+        <span className="panel-title">SSO Settings — Single Sign-On</span>
+      </div>
+
+      <div className="sso-field">
+        <label htmlFor="sso-enabled">Enable SSO</label>
+        <input
+          id="sso-enabled"
+          type="checkbox"
+          checked={config.enabled}
+          onChange={(e) => update({ enabled: e.target.checked })}
+        />
+      </div>
+
+      <div className="sso-field">
+        <label htmlFor="sso-provider">Provider</label>
+        <select
+          id="sso-provider"
+          value={config.provider}
+          onChange={(e) => update({ provider: e.target.value as SSOProvider })}
+        >
+          <option value="saml">SAML 2.0</option>
+          <option value="oidc">OIDC (OpenID Connect)</option>
+        </select>
+      </div>
+
+      {config.enabled && config.provider === 'saml' && (
+        <div className="saml-fields">
+          <h4>SAML Configuration</h4>
+          <div className="sso-field">
+            <label htmlFor="saml-entity-id">Entity ID</label>
+            <input
+              id="saml-entity-id"
+              type="text"
+              value={config.entityId}
+              onChange={(e) => update({ entityId: e.target.value })}
+              placeholder="https://your-idp.example.com"
+            />
+          </div>
+          <div className="sso-field">
+            <label htmlFor="saml-sso-url">SSO URL</label>
+            <input
+              id="saml-sso-url"
+              type="url"
+              value={config.ssoUrl}
+              onChange={(e) => update({ ssoUrl: e.target.value })}
+              placeholder="https://your-idp.example.com/sso"
+            />
+          </div>
+          <div className="sso-field">
+            <label htmlFor="saml-cert">X.509 Certificate</label>
+            <textarea
+              id="saml-cert"
+              value={config.certificate}
+              onChange={(e) => update({ certificate: e.target.value })}
+              placeholder="Paste your IdP X.509 certificate here…"
+              rows={4}
+            />
+          </div>
+        </div>
+      )}
+
+      {config.enabled && config.provider === 'oidc' && (
+        <div className="oidc-fields">
+          <h4>OIDC Configuration</h4>
+          <div className="sso-field">
+            <label htmlFor="oidc-client-id">Client ID</label>
+            <input
+              id="oidc-client-id"
+              type="text"
+              value={config.oidcClientId}
+              onChange={(e) => update({ oidcClientId: e.target.value })}
+              placeholder="your-client-id"
+            />
+          </div>
+          <div className="sso-field">
+            <label htmlFor="oidc-client-secret">Client Secret</label>
+            <input
+              id="oidc-client-secret"
+              type="password"
+              value={config.oidcClientSecret}
+              onChange={(e) => update({ oidcClientSecret: e.target.value })}
+              placeholder="••••••••••••••••"
+            />
+          </div>
+          <div className="sso-field">
+            <label htmlFor="oidc-discovery-url">Discovery URL</label>
+            <input
+              id="oidc-discovery-url"
+              type="url"
+              value={config.oidcDiscoveryUrl}
+              onChange={(e) => update({ oidcDiscoveryUrl: e.target.value })}
+              placeholder="https://your-idp.example.com/.well-known/openid-configuration"
+            />
+          </div>
+        </div>
+      )}
+
+      <button
+        aria-label="Save SSO settings"
+        className="btn-save"
+        onClick={() => onSave(config)}
+      >
+        Save Settings
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SSOSettingsPanel` for enterprise SAML 2.0 / OIDC identity provider integration
- SAML fields: Entity ID, SSO URL, X.509 certificate; OIDC fields: Client ID, secret, discovery URL

## Test plan
- [x] 8 unit tests passing
- [x] TypeScript strict mode passes

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)