### PR TITLE
feat(app): T-AI-030 spec writing panel with room data sheets

### DIFF
--- a/packages/app/src/components/SpecWritingPanel.test.tsx
+++ b/packages/app/src/components/SpecWritingPanel.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SpecWritingPanel, type RoomDataSheet } from './SpecWritingPanel';
+
+describe('T-AI-030: SpecWritingPanel', () => {
+  const onGenerate = vi.fn();
+  const onExport = vi.fn();
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const sheets: RoomDataSheet[] = [
+    {
+      id: 'rds-1',
+      roomName: 'Main Bedroom',
+      area: 18.5,
+      height: 2.7,
+      finishes: { floor: 'Timber', ceiling: 'Plaster', walls: 'Paint' },
+      services: ['Lighting', 'Power', 'Data'],
+      notes: 'Acoustic insulation required.',
+    },
+    {
+      id: 'rds-2',
+      roomName: 'Kitchen',
+      area: 12.0,
+      height: 2.7,
+      finishes: { floor: 'Tile', ceiling: 'Plaster', walls: 'Tile' },
+      services: ['Lighting', 'Power', 'Gas', 'Plumbing'],
+      notes: '',
+    },
+  ];
+
+  it('renders Spec Writing header', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getByText(/spec writing|room data/i)).toBeInTheDocument();
+  });
+
+  it('shows room names', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getByText('Main Bedroom')).toBeInTheDocument();
+    expect(screen.getByText('Kitchen')).toBeInTheDocument();
+  });
+
+  it('shows room area', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getAllByText(/18\.5|12\.0|m²/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows floor finish', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getAllByText(/timber|tile/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows Generate from Model button', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getByRole('button', { name: /generate/i })).toBeInTheDocument();
+  });
+
+  it('calls onGenerate when Generate clicked', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).toHaveBeenCalled();
+  });
+
+  it('shows Export button', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
+  });
+
+  it('calls onExport with sheets when Export clicked', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(onExport).toHaveBeenCalledWith(sheets);
+  });
+
+  it('shows services for each room', () => {
+    render(<SpecWritingPanel sheets={sheets} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getAllByText(/lighting|power|gas|plumbing/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows empty state when no sheets', () => {
+    render(<SpecWritingPanel sheets={[]} onGenerate={onGenerate} onExport={onExport} />);
+    expect(screen.getAllByText(/no room data|generate/i).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/components/SpecWritingPanel.tsx
+++ b/packages/app/src/components/SpecWritingPanel.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+export interface RoomFinishes {
+  floor: string;
+  ceiling: string;
+  walls: string;
+}
+
+export interface RoomDataSheet {
+  id: string;
+  roomName: string;
+  area: number;
+  height: number;
+  finishes: RoomFinishes;
+  services: string[];
+  notes: string;
+}
+
+interface SpecWritingPanelProps {
+  sheets: RoomDataSheet[];
+  onGenerate: () => void;
+  onExport: (sheets: RoomDataSheet[]) => void;
+}
+
+export function SpecWritingPanel({ sheets, onGenerate, onExport }: SpecWritingPanelProps) {
+  return (
+    <div className="spec-writing-panel">
+      <div className="panel-header">
+        <span className="panel-title">Spec Writing — Room Data Sheets</span>
+        <div className="spec-actions">
+          <button
+            aria-label="Generate from model"
+            className="btn-generate"
+            onClick={onGenerate}
+          >
+            Generate from Model
+          </button>
+          <button
+            aria-label="Export sheets"
+            className="btn-export"
+            onClick={() => onExport(sheets)}
+            disabled={sheets.length === 0}
+          >
+            Export
+          </button>
+        </div>
+      </div>
+
+      {sheets.length === 0 ? (
+        <div className="spec-empty">
+          No room data sheets. Click "Generate from Model" to create them from spaces in the model.
+        </div>
+      ) : (
+        <div className="sheets-list">
+          {sheets.map((sheet) => (
+            <div key={sheet.id} className="room-data-sheet">
+              <h4 className="sheet-room-name">{sheet.roomName}</h4>
+              <div className="sheet-details">
+                <div className="sheet-row">
+                  <span className="sheet-label">Area:</span>
+                  <span>{sheet.area} m²</span>
+                </div>
+                <div className="sheet-row">
+                  <span className="sheet-label">Height:</span>
+                  <span>{sheet.height} m</span>
+                </div>
+                <div className="sheet-finishes">
+                  <span className="sheet-label">Finishes:</span>
+                  <span>Floor: {sheet.finishes.floor}</span>
+                  <span>Ceiling: {sheet.finishes.ceiling}</span>
+                  <span>Walls: {sheet.finishes.walls}</span>
+                </div>
+                <div className="sheet-services">
+                  <span className="sheet-label">Services:</span>
+                  <span>{sheet.services.join(', ')}</span>
+                </div>
+                {sheet.notes && (
+                  <div className="sheet-notes">
+                    <span className="sheet-label">Notes:</span>
+                    <span>{sheet.notes}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SpecWritingPanel` for AI-generated room data sheets from model spaces
- Shows room name, area, height, finishes (floor/ceiling/walls), services, notes
- Generate from Model and Export actions

## Test plan
- [x] 10 unit tests passing
- [x] TypeScript strict mode passes

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)