### PR TITLE
feat(infra): T-INFRA-002 release pipeline with semantic-release and Docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:
@@ -14,8 +16,40 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
+  # ──────────────────────────────────────────────────────────────
+  # 0. Semantic Release (runs on push to main, cuts version + changelog)
+  # ──────────────────────────────────────────────────────────────
+  semantic-release:
+    name: Semantic Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
+
   # ──────────────────────────────────────────────────────────────
   # 1. Validate Release
   # ──────────────────────────────────────────────────────────────
@@ -204,11 +238,56 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ──────────────────────────────────────────────────────────────
-  # 5. Notify Community
+  # 5. Build & Push Docker Image
+  # ──────────────────────────────────────────────────────────────
+  docker:
+    name: Docker Image
+    needs: [validate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/carihq/opencad-api
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+  # ──────────────────────────────────────────────────────────────
+  # 6. Notify Community
   # ──────────────────────────────────────────────────────────────
   notify:
     name: Notify Community
-    needs: release
+    needs: [release, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,25 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    ["@semantic-release/github", {
+      "assets": [
+        { "path": "artifacts/**/*.dmg", "label": "macOS Installer" },
+        { "path": "artifacts/**/*.exe", "label": "Windows Installer" },
+        { "path": "artifacts/**/*.deb", "label": "Linux (deb)" },
+        { "path": "artifacts/**/*.AppImage", "label": "Linux (AppImage)" }
+      ]
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md", "package.json", "packages/*/package.json"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# OpenCAD API Server — Production Docker Image
+FROM node:20-alpine AS base
+RUN npm install -g pnpm@9
+WORKDIR /app
+
+# Install dependencies
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/document/package.json packages/document/
+COPY packages/ai/package.json packages/ai/
+COPY packages/sync/package.json packages/sync/
+RUN pnpm install --frozen-lockfile --prod
+
+# Build
+FROM base AS builder
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY packages/ packages/
+RUN pnpm install --frozen-lockfile
+RUN pnpm build
+
+# Production image
+FROM node:20-alpine AS runner
+RUN addgroup --system --gid 1001 opencad && \
+    adduser --system --uid 1001 opencad
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/packages/sync/dist ./packages/sync/dist
+COPY --from=builder /app/packages/document/dist ./packages/document/dist
+COPY --from=builder /app/packages/ai/dist ./packages/ai/dist
+COPY --from=builder /app/package.json ./
+
+USER opencad
+EXPOSE 3000
+ENV NODE_ENV=production
+ENV PORT=3000
+
+CMD ["node", "packages/sync/dist/server.js"]

--- a/packages/app/src/lib/semver.test.ts
+++ b/packages/app/src/lib/semver.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parseSemver, bumpVersion, isPrerelease } from './semver';
+
+describe('T-INFRA-002: Semantic versioning utilities', () => {
+  it('parses a valid semver string', () => {
+    const v = parseSemver('1.2.3');
+    expect(v).toEqual({ major: 1, minor: 2, patch: 3, prerelease: null });
+  });
+
+  it('parses a prerelease semver', () => {
+    const v = parseSemver('2.0.0-rc.1');
+    expect(v?.prerelease).toBe('rc.1');
+  });
+
+  it('returns null for invalid semver', () => {
+    expect(parseSemver('not-a-version')).toBeNull();
+  });
+
+  it('bumps patch version', () => {
+    expect(bumpVersion('1.2.3', 'patch')).toBe('1.2.4');
+  });
+
+  it('bumps minor version and resets patch', () => {
+    expect(bumpVersion('1.2.3', 'minor')).toBe('1.3.0');
+  });
+
+  it('bumps major version and resets minor/patch', () => {
+    expect(bumpVersion('1.2.3', 'major')).toBe('2.0.0');
+  });
+
+  it('identifies prerelease versions', () => {
+    expect(isPrerelease('1.0.0-rc.1')).toBe(true);
+    expect(isPrerelease('1.0.0-beta')).toBe(true);
+    expect(isPrerelease('1.0.0-alpha.1')).toBe(true);
+    expect(isPrerelease('1.0.0')).toBe(false);
+  });
+
+  it('formats version as v-prefixed tag', () => {
+    const v = parseSemver('3.1.4');
+    expect(v ? `v${v.major}.${v.minor}.${v.patch}` : '').toBe('v3.1.4');
+  });
+});

--- a/packages/app/src/lib/semver.ts
+++ b/packages/app/src/lib/semver.ts
@@ -1,0 +1,35 @@
+export interface SemverVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+}
+
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/;
+
+export function parseSemver(version: string): SemverVersion | null {
+  const m = SEMVER_RE.exec(version);
+  if (!m) return null;
+  return {
+    major: parseInt(m[1]!),
+    minor: parseInt(m[2]!),
+    patch: parseInt(m[3]!),
+    prerelease: m[4] ?? null,
+  };
+}
+
+export function bumpVersion(version: string, type: 'major' | 'minor' | 'patch'): string {
+  const v = parseSemver(version);
+  if (!v) throw new Error(`Invalid semver: ${version}`);
+
+  switch (type) {
+    case 'major': return `${v.major + 1}.0.0`;
+    case 'minor': return `${v.major}.${v.minor + 1}.0`;
+    case 'patch': return `${v.major}.${v.minor}.${v.patch + 1}`;
+  }
+}
+
+export function isPrerelease(version: string): boolean {
+  const v = parseSemver(version);
+  return v !== null && v.prerelease !== null;
+}


### PR DESCRIPTION
## Summary
- Adds semantic-release config (`.releaserc.json`) for automatic version bumping from conventional commits
- Adds Docker image build and push job to GHCR (`ghcr.io/carihq/opencad-api`) on tagged releases
- Adds `Dockerfile` (multi-stage: deps → builder → production runner)
- Enhances release workflow: runs semantic-release on push to main, then tags trigger the full build pipeline
- Adds `semver.ts` utility library with unit tests

## Test plan
- [x] 8 semver utility unit tests passing
- [x] TypeScript strict mode passes

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)