### PR TITLE
fix(ci): fix deploy pipeline failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build and push server image
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/opencad/${{ env.SERVICE }}:${{ github.sha }}"
-          docker build --file Dockerfile --tag "$IMAGE" \
-            --tag "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/opencad/${{ env.SERVICE }}:latest" .
+          docker build --file server/Dockerfile --tag "$IMAGE" \
+            --tag "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/opencad/${{ env.SERVICE }}:latest" server/
           docker push "$IMAGE"
           docker push "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/opencad/${{ env.SERVICE }}:latest"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
@@ -163,8 +163,6 @@ jobs:
           echo "APP_BUCKET=$(sm opencad-app-bucket)"                                    >> "$GITHUB_ENV"
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Enable IAM Service Account Credentials API (`iamcredentials.googleapis.com`) — was disabled, causing all WIF auth token exchanges to fail, which silently emptied every Secret Manager variable
- Fix Dockerfile build path: use `server/Dockerfile` with `server/` build context instead of the stub root `Dockerfile` that contained only comments
- Remove explicit `version: 9` from `pnpm/action-setup@v4` to resolve conflict with `packageManager: pnpm@9.0.0` in `package.json`

All three deploy jobs were failing on run 24572722604 due to these issues.

## Test plan
- [ ] All three jobs pass: Build & deploy server, Deploy landing page, Build & deploy web app
- [ ] `opencad.archi` landing page updates on GCS
- [ ] `app.opencad.archi` React app live with Firebase auth working
- [ ] Cloud Run service updated with new server image

🤖 Generated with [Claude Code](https://claude.com/claude-code)