### PR TITLE
fix(deploy): build workspace dependencies before frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,9 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      - name: Build workspace dependencies
+        run: pnpm --filter=!@opencad/app --filter=!@opencad/desktop --filter=!@opencad/e2e build
+
       - name: Build frontend
         env:
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}


### PR DESCRIPTION
## Summary

- The `deploy-frontend` CI job was running `pnpm --filter=@opencad/app build` without first building `@opencad/document`, `@opencad/ai`, and other workspace dependencies
- TypeScript couldn't find type declarations for those packages, causing cascading `TS18046` (`'x' is of type 'unknown'`) and `TS2307` (`Cannot find module '@opencad/ai'`) errors that failed every production deploy
- Added a **Build workspace dependencies** step before the app build step

## Root cause

`Object.values(doc.organization.layers)` in `LayerPanel.tsx` was returning `unknown[]` because `LayerSchema` from `@opencad/document` wasn't resolvable — the `dist/` types hadn't been compiled yet in that job.

## Test plan
- [x] Fix is minimal and mechanical — just adds a build step before the failing one
- [ ] Verify next production deploy succeeds through the Firebase Hosting step

🤖 Generated with [Claude Code](https://claude.com/claude-code)