### PR TITLE
fix(deploy): build only pure-JS deps before frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build workspace dependencies
-        run: pnpm --filter=!@opencad/app --filter=!@opencad/desktop --filter=!@opencad/e2e build
+        run: |
+          # Build only pure-JS packages — sync-rs needs wasm-pack which isn't available here
+          pnpm --filter=@opencad/shared --filter=@opencad/document --filter=@opencad/ai --filter=@opencad/geometry build
 
       - name: Build frontend
         env:


### PR DESCRIPTION
## Summary

- Previous fix (#265) excluded sync-rs but still included @opencad/sync which depends on it
- sync-rs requires wasm-pack which isn't in the deploy-frontend job
- Narrow to only the pure-JS packages that provide types the app needs: shared, document, ai, geometry
- These have no Rust/WASM step and build in seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)