### PR TITLE
fix(deploy): drop geometry from pre-build (also has WASM)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,8 +112,8 @@ jobs:
 
       - name: Build workspace dependencies
         run: |
-          # Build only pure-JS packages — sync-rs needs wasm-pack which isn't available here
-          pnpm --filter=@opencad/shared --filter=@opencad/document --filter=@opencad/ai --filter=@opencad/geometry build
+          # Build pure-JS packages only (no WASM — sync-rs and geometry need wasm-pack)
+          pnpm --filter=@opencad/shared --filter=@opencad/document --filter=@opencad/ai build
 
       - name: Build frontend
         env:


### PR DESCRIPTION
## Summary

- @opencad/geometry has a wasm build step (pnpm build:wasm) like sync-rs
- Only build shared, document, ai — the three packages whose TypeScript declarations the app actually needs and which have no WASM deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)