### PR TITLE
feat(desktop): add native OS menu bar with File/Edit/View/Tools/Help

### DIFF
--- a/packages/app/src/hooks/useMenuBar.test.ts
+++ b/packages/app/src/hooks/useMenuBar.test.ts
@@ -1,0 +1,284 @@
+/**
+ * T-DSK-007: Native OS Menu Bar — unit tests
+ *
+ * These tests verify that `dispatchMenuEvent` routes each menu item ID to the
+ * correct store action or side-effect handler, without needing a real Tauri
+ * runtime or a React component tree.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { dispatchMenuEvent } from './useMenuBar';
+
+// ── Minimal store mock ────────────────────────────────────────────────────────
+function makeStore() {
+  return {
+    undo: vi.fn(),
+    redo: vi.fn(),
+    setActiveTool: vi.fn(),
+  };
+}
+
+// ── Helper: reset DOM globals between tests ───────────────────────────────────
+beforeEach(() => {
+  document.documentElement.removeAttribute('data-theme');
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-01  Edit → Undo calls store.undo()
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-01: edit-undo', () => {
+  it('calls store.undo()', () => {
+    const store = makeStore();
+    dispatchMenuEvent('edit-undo', store);
+    expect(store.undo).toHaveBeenCalledOnce();
+    expect(store.redo).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-02  Edit → Redo calls store.redo()
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-02: edit-redo', () => {
+  it('calls store.redo()', () => {
+    const store = makeStore();
+    dispatchMenuEvent('edit-redo', store);
+    expect(store.redo).toHaveBeenCalledOnce();
+    expect(store.undo).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-03  Tool menu items → store.setActiveTool()
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-03: tool menu → setActiveTool', () => {
+  const cases: Array<[string, string]> = [
+    ['tool-select', 'select'],
+    ['tool-line', 'line'],
+    ['tool-rectangle', 'rectangle'],
+    ['tool-circle', 'circle'],
+    ['tool-arc', 'arc'],
+    ['tool-wall', 'wall'],
+    ['tool-door', 'door'],
+    ['tool-window', 'window'],
+    ['tool-dimension', 'dimension'],
+    ['tool-text', 'text'],
+  ];
+
+  it.each(cases)('menu id "%s" sets active tool "%s"', (menuId, expectedTool) => {
+    const store = makeStore();
+    dispatchMenuEvent(menuId, store);
+    expect(store.setActiveTool).toHaveBeenCalledWith(expectedTool);
+    expect(store.undo).not.toHaveBeenCalled();
+    expect(store.redo).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-04  File menu items → handler callbacks
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-04: file menu → handler callbacks', () => {
+  it('file-new calls onNewProject', () => {
+    const store = makeStore();
+    const onNewProject = vi.fn();
+    dispatchMenuEvent('file-new', store, { onNewProject });
+    expect(onNewProject).toHaveBeenCalledOnce();
+  });
+
+  it('file-open calls onOpenFile', () => {
+    const store = makeStore();
+    const onOpenFile = vi.fn();
+    dispatchMenuEvent('file-open', store, { onOpenFile });
+    expect(onOpenFile).toHaveBeenCalledOnce();
+  });
+
+  it('file-save calls onSaveFile', () => {
+    const store = makeStore();
+    const onSaveFile = vi.fn();
+    dispatchMenuEvent('file-save', store, { onSaveFile });
+    expect(onSaveFile).toHaveBeenCalledOnce();
+  });
+
+  it('file-save-as calls onSaveFileAs', () => {
+    const store = makeStore();
+    const onSaveFileAs = vi.fn();
+    dispatchMenuEvent('file-save-as', store, { onSaveFileAs });
+    expect(onSaveFileAs).toHaveBeenCalledOnce();
+  });
+
+  it('file-export calls onExport', () => {
+    const store = makeStore();
+    const onExport = vi.fn();
+    dispatchMenuEvent('file-export', store, { onExport });
+    expect(onExport).toHaveBeenCalledOnce();
+  });
+
+  it('file-new does NOT call store.undo/redo', () => {
+    const store = makeStore();
+    dispatchMenuEvent('file-new', store, {});
+    expect(store.undo).not.toHaveBeenCalled();
+    expect(store.redo).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-05  Import submenu → onImport(format)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-05: import menu → onImport(format)', () => {
+  const importCases: Array<[string, string]> = [
+    ['import-ifc', 'ifc'],
+    ['import-dwg', 'dwg'],
+    ['import-pdf', 'pdf'],
+    ['import-revit', 'revit'],
+    ['import-sketchup', 'sketchup'],
+  ];
+
+  it.each(importCases)('menu id "%s" calls onImport("%s")', (menuId, format) => {
+    const store = makeStore();
+    const onImport = vi.fn();
+    dispatchMenuEvent(menuId, store, { onImport });
+    expect(onImport).toHaveBeenCalledWith(format);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-06  View zoom menu → onZoom(direction)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-06: view zoom menu → onZoom', () => {
+  it('view-zoom-in calls onZoom("in")', () => {
+    const store = makeStore();
+    const onZoom = vi.fn();
+    dispatchMenuEvent('view-zoom-in', store, { onZoom });
+    expect(onZoom).toHaveBeenCalledWith('in');
+  });
+
+  it('view-zoom-out calls onZoom("out")', () => {
+    const store = makeStore();
+    const onZoom = vi.fn();
+    dispatchMenuEvent('view-zoom-out', store, { onZoom });
+    expect(onZoom).toHaveBeenCalledWith('out');
+  });
+
+  it('view-zoom-fit calls onZoom("fit")', () => {
+    const store = makeStore();
+    const onZoom = vi.fn();
+    dispatchMenuEvent('view-zoom-fit', store, { onZoom });
+    expect(onZoom).toHaveBeenCalledWith('fit');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-07  View panel toggle → onTogglePanel(panel)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-07: view panel toggle → onTogglePanel', () => {
+  const panelCases: Array<[string, string]> = [
+    ['view-panel-layers', 'layers'],
+    ['view-panel-properties', 'properties'],
+    ['view-panel-ai-chat', 'ai-chat'],
+  ];
+
+  it.each(panelCases)('menu id "%s" calls onTogglePanel("%s")', (menuId, panel) => {
+    const store = makeStore();
+    const onTogglePanel = vi.fn();
+    dispatchMenuEvent(menuId, store, { onTogglePanel });
+    expect(onTogglePanel).toHaveBeenCalledWith(panel);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-08  View dark / light mode → data-theme attribute + localStorage
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-08: view dark/light mode', () => {
+  it('view-dark-mode sets data-theme="dark" and saves to localStorage', () => {
+    const store = makeStore();
+    dispatchMenuEvent('view-dark-mode', store);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('view-light-mode sets data-theme="light" and saves to localStorage', () => {
+    const store = makeStore();
+    dispatchMenuEvent('view-light-mode', store);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-09  View toggle 2D/3D → dispatches CustomEvent on window
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-09: view-toggle-2d-3d', () => {
+  it('dispatches "opencad:toggle-view" on window', () => {
+    const store = makeStore();
+    const handler = vi.fn();
+    window.addEventListener('opencad:toggle-view', handler);
+
+    dispatchMenuEvent('view-toggle-2d-3d', store);
+    expect(handler).toHaveBeenCalledOnce();
+
+    window.removeEventListener('opencad:toggle-view', handler);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-10  Help menu → custom window events
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-10: help menu', () => {
+  it('help-about dispatches "opencad:show-about" on window', () => {
+    const store = makeStore();
+    const handler = vi.fn();
+    window.addEventListener('opencad:show-about', handler);
+
+    dispatchMenuEvent('help-about', store);
+    expect(handler).toHaveBeenCalledOnce();
+
+    window.removeEventListener('opencad:show-about', handler);
+  });
+
+  it('help-check-updates dispatches "opencad:check-updates" on window', () => {
+    const store = makeStore();
+    const handler = vi.fn();
+    window.addEventListener('opencad:check-updates', handler);
+
+    dispatchMenuEvent('help-check-updates', store);
+    expect(handler).toHaveBeenCalledOnce();
+
+    window.removeEventListener('opencad:check-updates', handler);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-11  Unknown menu IDs are silently ignored
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-11: unknown menu IDs', () => {
+  it('does not throw for an unrecognised menu event id', () => {
+    const store = makeStore();
+    expect(() => dispatchMenuEvent('totally-unknown-id', store)).not.toThrow();
+    expect(store.undo).not.toHaveBeenCalled();
+    expect(store.redo).not.toHaveBeenCalled();
+    expect(store.setActiveTool).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// T-DSK-007-12  Handlers are optional — no error when omitted
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('T-DSK-007-12: optional handlers', () => {
+  it('file-new with no handlers does not throw', () => {
+    const store = makeStore();
+    expect(() => dispatchMenuEvent('file-new', store)).not.toThrow();
+  });
+
+  it('import-ifc with no handlers does not throw', () => {
+    const store = makeStore();
+    expect(() => dispatchMenuEvent('import-ifc', store)).not.toThrow();
+  });
+
+  it('view-zoom-in with no handlers does not throw', () => {
+    const store = makeStore();
+    expect(() => dispatchMenuEvent('view-zoom-in', store)).not.toThrow();
+  });
+});

--- a/packages/app/src/hooks/useMenuBar.ts
+++ b/packages/app/src/hooks/useMenuBar.ts
@@ -1,0 +1,301 @@
+/**
+ * T-DSK-007: Native OS Menu Bar event handler hook.
+ *
+ * Listens for Tauri `"menu"` events (emitted from Rust via `app.emit("menu", id)`)
+ * and dispatches the corresponding actions to the document store or fires
+ * browser-level side-effects (zoom, panel visibility, theme, dialogs).
+ *
+ * The hook is a no-op when running outside the Tauri desktop shell so the
+ * browser app is unaffected.
+ */
+
+import { useEffect } from 'react';
+import { useDocumentStore } from '../stores/documentStore';
+import { isTauri } from './useTauri';
+
+/** Subset of menu item IDs that the frontend handles. */
+export type MenuItemId =
+  // File
+  | 'file-new'
+  | 'file-open'
+  | 'file-save'
+  | 'file-save-as'
+  | 'import-ifc'
+  | 'import-dwg'
+  | 'import-pdf'
+  | 'import-revit'
+  | 'import-sketchup'
+  | 'file-export'
+  | 'file-close'
+  // Edit
+  | 'edit-undo'
+  | 'edit-redo'
+  | 'edit-delete'
+  // View
+  | 'view-zoom-in'
+  | 'view-zoom-out'
+  | 'view-zoom-fit'
+  | 'view-toggle-2d-3d'
+  | 'view-panel-layers'
+  | 'view-panel-properties'
+  | 'view-panel-ai-chat'
+  | 'view-dark-mode'
+  | 'view-light-mode'
+  // Tools
+  | 'tool-select'
+  | 'tool-line'
+  | 'tool-rectangle'
+  | 'tool-circle'
+  | 'tool-arc'
+  | 'tool-wall'
+  | 'tool-door'
+  | 'tool-window'
+  | 'tool-dimension'
+  | 'tool-text'
+  // Help
+  | 'help-about'
+  | 'help-check-updates'
+  | 'help-docs';
+
+/** Tool IDs that map directly to documentStore.setActiveTool() values. */
+const TOOL_MENU_MAP: Partial<Record<MenuItemId, string>> = {
+  'tool-select': 'select',
+  'tool-line': 'line',
+  'tool-rectangle': 'rectangle',
+  'tool-circle': 'circle',
+  'tool-arc': 'arc',
+  'tool-wall': 'wall',
+  'tool-door': 'door',
+  'tool-window': 'window',
+  'tool-dimension': 'dimension',
+  'tool-text': 'text',
+};
+
+export interface MenuBarHandlers {
+  /** Override the default "file-new" handler. */
+  onNewProject?: () => void;
+  /** Override the default "file-open" handler. */
+  onOpenFile?: () => void;
+  /** Override the default "file-save" handler. */
+  onSaveFile?: () => void;
+  /** Override the default "file-save-as" handler. */
+  onSaveFileAs?: () => void;
+  /** Receives the format string: 'ifc' | 'dwg' | 'pdf' | 'revit' | 'sketchup'. */
+  onImport?: (format: string) => void;
+  /** Called when the user chooses File > Export. */
+  onExport?: () => void;
+  /** Called for view toggle events: 'layers' | 'properties' | 'ai-chat'. */
+  onTogglePanel?: (panel: string) => void;
+  /** Called when user zooms via menu: 'in' | 'out' | 'fit'. */
+  onZoom?: (direction: 'in' | 'out' | 'fit') => void;
+}
+
+/**
+ * Dispatch a single menu event ID to the document store or a provided handler.
+ * Exported for unit testing without React lifecycle overhead.
+ */
+export function dispatchMenuEvent(
+  id: string,
+  store: {
+    undo: () => void;
+    redo: () => void;
+    setActiveTool: (tool: string) => void;
+  },
+  handlers: MenuBarHandlers = {}
+): void {
+  const menuId = id as MenuItemId;
+
+  // ── Tool selection ─────────────────────────────────────────────────────────
+  const toolName = TOOL_MENU_MAP[menuId];
+  if (toolName !== undefined) {
+    store.setActiveTool(toolName);
+    return;
+  }
+
+  switch (menuId) {
+    // ── File ──────────────────────────────────────────────────────────────
+    case 'file-new':
+      handlers.onNewProject?.();
+      break;
+
+    case 'file-open':
+      handlers.onOpenFile?.();
+      break;
+
+    case 'file-save':
+      handlers.onSaveFile?.();
+      break;
+
+    case 'file-save-as':
+      handlers.onSaveFileAs?.();
+      break;
+
+    case 'import-ifc':
+      handlers.onImport?.('ifc');
+      break;
+
+    case 'import-dwg':
+      handlers.onImport?.('dwg');
+      break;
+
+    case 'import-pdf':
+      handlers.onImport?.('pdf');
+      break;
+
+    case 'import-revit':
+      handlers.onImport?.('revit');
+      break;
+
+    case 'import-sketchup':
+      handlers.onImport?.('sketchup');
+      break;
+
+    case 'file-export':
+      handlers.onExport?.();
+      break;
+
+    case 'file-close':
+      if (typeof window !== 'undefined') {
+        window.close();
+      }
+      break;
+
+    // ── Edit ──────────────────────────────────────────────────────────────
+    case 'edit-undo':
+      store.undo();
+      break;
+
+    case 'edit-redo':
+      store.redo();
+      break;
+
+    // ── View ──────────────────────────────────────────────────────────────
+    case 'view-zoom-in':
+      handlers.onZoom?.('in');
+      break;
+
+    case 'view-zoom-out':
+      handlers.onZoom?.('out');
+      break;
+
+    case 'view-zoom-fit':
+      handlers.onZoom?.('fit');
+      break;
+
+    case 'view-toggle-2d-3d':
+      // Dispatch a custom DOM event so the Viewport component can respond.
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('opencad:toggle-view'));
+      }
+      break;
+
+    case 'view-panel-layers':
+      handlers.onTogglePanel?.('layers');
+      break;
+
+    case 'view-panel-properties':
+      handlers.onTogglePanel?.('properties');
+      break;
+
+    case 'view-panel-ai-chat':
+      handlers.onTogglePanel?.('ai-chat');
+      break;
+
+    case 'view-dark-mode':
+      if (typeof document !== 'undefined') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        try {
+          localStorage.setItem('theme', 'dark');
+        } catch { /* ignore */ }
+      }
+      break;
+
+    case 'view-light-mode':
+      if (typeof document !== 'undefined') {
+        document.documentElement.setAttribute('data-theme', 'light');
+        try {
+          localStorage.setItem('theme', 'light');
+        } catch { /* ignore */ }
+      }
+      break;
+
+    // ── Help ──────────────────────────────────────────────────────────────
+    case 'help-about':
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('opencad:show-about'));
+      }
+      break;
+
+    case 'help-check-updates':
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('opencad:check-updates'));
+      }
+      break;
+
+    case 'help-docs':
+      if (typeof window !== 'undefined') {
+        window.open('https://opencad.archi/docs', '_blank');
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+
+/** Tauri v2 event API shape (accessed through the window global). */
+interface TauriEventApi {
+  listen: <T>(
+    event: string,
+    handler: (payload: { payload: T }) => void
+  ) => Promise<() => void>;
+}
+
+/** Extended Tauri window global that includes the event submodule. */
+interface TauriWithEvent {
+  core: { invoke: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T> };
+  event?: TauriEventApi;
+}
+
+/**
+ * React hook that registers the Tauri menu event listener.
+ * Call once at the application root (e.g. in AppLayout).
+ *
+ * @param handlers - Optional overrides for file/view/panel actions.
+ */
+export function useMenuBar(handlers: MenuBarHandlers = {}): void {
+  const undo = useDocumentStore((s) => s.undo);
+  const redo = useDocumentStore((s) => s.redo);
+  const setActiveTool = useDocumentStore((s) => s.setActiveTool);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    // Access the Tauri event API through the window global to avoid a hard
+    // dependency on @tauri-apps/api in the app package.  Cast to the extended
+    // type so TypeScript knows about the optional `event` submodule.
+    const tauri = window.__TAURI__ as TauriWithEvent | undefined;
+    const tauriEvent = tauri?.event;
+    if (!tauriEvent) return;
+
+    let unlisten: (() => void) | undefined;
+
+    tauriEvent
+      .listen<string>('menu', (evt) => {
+        dispatchMenuEvent(evt.payload, { undo, redo, setActiveTool }, handlers);
+      })
+      .then((fn) => {
+        unlisten = fn;
+      })
+      .catch(() => {
+        // Tauri event API unavailable — silently ignore.
+      });
+
+    return () => {
+      unlisten?.();
+    };
+    // handlers is intentionally excluded so the effect doesn't re-run on every
+    // render if consumers pass an inline object literal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [undo, redo, setActiveTool]);
+}

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri_plugin_dialog::{DialogExt, FilePath};
 
 struct AppState {
@@ -473,6 +474,214 @@ fn get_synced_document() -> Result<Option<String>, String> {
     Ok(None)
 }
 
+/// T-DSK-007: Build the native OS menu bar.
+/// Uses Tauri v2 `tauri::menu` API.  All menu item IDs are lowercase-hyphen
+/// strings that the frontend listens for via the Tauri window global.
+fn build_menu(handle: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
+    // ── File menu ─────────────────────────────────────────────────────────────
+    let file_menu = Submenu::with_items(
+        handle,
+        "File",
+        true,
+        &[
+            &MenuItem::with_id(handle, "file-new", "New Project", true, Some("CmdOrCtrl+N"))?,
+            &MenuItem::with_id(handle, "file-open", "Open\u{2026}", true, Some("CmdOrCtrl+O"))?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(handle, "file-save", "Save", true, Some("CmdOrCtrl+S"))?,
+            &MenuItem::with_id(
+                handle,
+                "file-save-as",
+                "Save As\u{2026}",
+                true,
+                Some("CmdOrCtrl+Shift+S"),
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &Submenu::with_items(
+                handle,
+                "Import",
+                true,
+                &[
+                    &MenuItem::with_id(handle, "import-ifc", "IFC\u{2026}", true, None::<&str>)?,
+                    &MenuItem::with_id(handle, "import-dwg", "DWG\u{2026}", true, None::<&str>)?,
+                    &MenuItem::with_id(handle, "import-pdf", "PDF\u{2026}", true, None::<&str>)?,
+                    &MenuItem::with_id(
+                        handle,
+                        "import-revit",
+                        "Revit (RVT)\u{2026}",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        "import-sketchup",
+                        "SketchUp (SKP)\u{2026}",
+                        true,
+                        None::<&str>,
+                    )?,
+                ],
+            )?,
+            &MenuItem::with_id(
+                handle,
+                "file-export",
+                "Export\u{2026}",
+                true,
+                None::<&str>,
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(handle, "file-recent", "Recent Files", false, None::<&str>)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(handle, "file-close", "Close", true, Some("CmdOrCtrl+W"))?,
+        ],
+    )?;
+
+    // ── Edit menu ─────────────────────────────────────────────────────────────
+    let edit_menu = Submenu::with_items(
+        handle,
+        "Edit",
+        true,
+        &[
+            &MenuItem::with_id(handle, "edit-undo", "Undo", true, Some("CmdOrCtrl+Z"))?,
+            &MenuItem::with_id(
+                handle,
+                "edit-redo",
+                "Redo",
+                true,
+                Some("CmdOrCtrl+Shift+Z"),
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::cut(handle, None)?,
+            &PredefinedMenuItem::copy(handle, None)?,
+            &PredefinedMenuItem::paste(handle, None)?,
+            &MenuItem::with_id(handle, "edit-delete", "Delete", true, None::<&str>)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::select_all(handle, None)?,
+        ],
+    )?;
+
+    // ── View menu ─────────────────────────────────────────────────────────────
+    let view_menu = Submenu::with_items(
+        handle,
+        "View",
+        true,
+        &[
+            &MenuItem::with_id(
+                handle,
+                "view-zoom-in",
+                "Zoom In",
+                true,
+                Some("CmdOrCtrl+Plus"),
+            )?,
+            &MenuItem::with_id(
+                handle,
+                "view-zoom-out",
+                "Zoom Out",
+                true,
+                Some("CmdOrCtrl+Minus"),
+            )?,
+            &MenuItem::with_id(
+                handle,
+                "view-zoom-fit",
+                "Zoom to Fit",
+                true,
+                Some("CmdOrCtrl+0"),
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(
+                handle,
+                "view-toggle-2d-3d",
+                "Toggle 2D / 3D",
+                true,
+                Some("CmdOrCtrl+Shift+3"),
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(
+                handle,
+                "view-panel-layers",
+                "Show/Hide Layers",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(
+                handle,
+                "view-panel-properties",
+                "Show/Hide Properties",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(
+                handle,
+                "view-panel-ai-chat",
+                "Show/Hide AI Chat",
+                true,
+                None::<&str>,
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(handle, "view-dark-mode", "Dark Mode", true, None::<&str>)?,
+            &MenuItem::with_id(handle, "view-light-mode", "Light Mode", true, None::<&str>)?,
+        ],
+    )?;
+
+    // ── Tools menu ────────────────────────────────────────────────────────────
+    let tools_menu = Submenu::with_items(
+        handle,
+        "Tools",
+        true,
+        &[
+            &MenuItem::with_id(handle, "tool-select", "Select", true, Some("V"))?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(handle, "tool-line", "Line", true, Some("L"))?,
+            &MenuItem::with_id(handle, "tool-rectangle", "Rectangle", true, Some("R"))?,
+            &MenuItem::with_id(handle, "tool-circle", "Circle", true, Some("C"))?,
+            &MenuItem::with_id(handle, "tool-arc", "Arc", true, Some("A"))?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(handle, "tool-wall", "Wall", true, Some("W"))?,
+            &MenuItem::with_id(handle, "tool-door", "Door", true, Some("D"))?,
+            &MenuItem::with_id(handle, "tool-window", "Window", true, None::<&str>)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(handle, "tool-dimension", "Dimension", true, None::<&str>)?,
+            &MenuItem::with_id(handle, "tool-text", "Text", true, Some("T"))?,
+        ],
+    )?;
+
+    // ── Help menu ─────────────────────────────────────────────────────────────
+    let help_menu = Submenu::with_items(
+        handle,
+        "Help",
+        true,
+        &[
+            &MenuItem::with_id(
+                handle,
+                "help-about",
+                "About OpenCAD",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(
+                handle,
+                "help-check-updates",
+                "Check for Updates\u{2026}",
+                true,
+                None::<&str>,
+            )?,
+            &MenuItem::with_id(handle, "help-docs", "Documentation", true, None::<&str>)?,
+        ],
+    )?;
+
+    Menu::with_items(
+        handle,
+        &[&file_menu, &edit_menu, &view_menu, &tools_menu, &help_menu],
+    )
+}
+
+/// T-DSK-007: Route menu events to the frontend via Tauri events.
+/// The frontend listens for `"menu"` events with a string payload (the menu item ID).
+fn handle_menu_event(app: &AppHandle, id: &str) {
+    info!("Menu event: {}", id);
+    if let Err(e) = app.emit("menu", id) {
+        warn!("Failed to emit menu event '{}': {}", id, e);
+    }
+}
+
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -491,7 +700,16 @@ fn main() {
     let db_for_sync = Arc::clone(&db);
 
     tauri::Builder::default()
-        .setup(move |_app| {
+        .setup(move |app| {
+            // ── T-DSK-007: Native OS Menu Bar ─────────────────────────────────
+            let menu = build_menu(app.handle())?;
+            app.set_menu(menu)?;
+
+            let app_handle = app.handle().clone();
+            app.on_menu_event(move |_app, event| {
+                handle_menu_event(&app_handle, event.id().as_ref());
+            });
+
             // Spawn the local WebSocket sync server so both the Tauri webview
             // and any browser tabs on the same machine can sync document data.
             tauri::async_runtime::spawn(sync_server::run_sync_server(db_for_sync));

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
+use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_dialog::{DialogExt, FilePath};
 
 struct AppState {
@@ -485,7 +485,13 @@ fn build_menu(handle: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         true,
         &[
             &MenuItem::with_id(handle, "file-new", "New Project", true, Some("CmdOrCtrl+N"))?,
-            &MenuItem::with_id(handle, "file-open", "Open\u{2026}", true, Some("CmdOrCtrl+O"))?,
+            &MenuItem::with_id(
+                handle,
+                "file-open",
+                "Open\u{2026}",
+                true,
+                Some("CmdOrCtrl+O"),
+            )?,
             &PredefinedMenuItem::separator(handle)?,
             &MenuItem::with_id(handle, "file-save", "Save", true, Some("CmdOrCtrl+S"))?,
             &MenuItem::with_id(
@@ -520,13 +526,7 @@ fn build_menu(handle: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                     )?,
                 ],
             )?,
-            &MenuItem::with_id(
-                handle,
-                "file-export",
-                "Export\u{2026}",
-                true,
-                None::<&str>,
-            )?,
+            &MenuItem::with_id(handle, "file-export", "Export\u{2026}", true, None::<&str>)?,
             &PredefinedMenuItem::separator(handle)?,
             &MenuItem::with_id(handle, "file-recent", "Recent Files", false, None::<&str>)?,
             &PredefinedMenuItem::separator(handle)?,
@@ -541,13 +541,7 @@ fn build_menu(handle: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         true,
         &[
             &MenuItem::with_id(handle, "edit-undo", "Undo", true, Some("CmdOrCtrl+Z"))?,
-            &MenuItem::with_id(
-                handle,
-                "edit-redo",
-                "Redo",
-                true,
-                Some("CmdOrCtrl+Shift+Z"),
-            )?,
+            &MenuItem::with_id(handle, "edit-redo", "Redo", true, Some("CmdOrCtrl+Shift+Z"))?,
             &PredefinedMenuItem::separator(handle)?,
             &PredefinedMenuItem::cut(handle, None)?,
             &PredefinedMenuItem::copy(handle, None)?,
@@ -649,13 +643,7 @@ fn build_menu(handle: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         "Help",
         true,
         &[
-            &MenuItem::with_id(
-                handle,
-                "help-about",
-                "About OpenCAD",
-                true,
-                None::<&str>,
-            )?,
+            &MenuItem::with_id(handle, "help-about", "About OpenCAD", true, None::<&str>)?,
             &MenuItem::with_id(
                 handle,
                 "help-check-updates",


### PR DESCRIPTION
## Summary

- **Rust (`main.rs`)**: Adds `build_menu()` using Tauri v2 `tauri::menu` API with five submenus — File (New/Open/Save/Save As/Import/Export/Close), Edit (Undo/Redo/Cut/Copy/Paste/Delete/Select All), View (Zoom In/Out/Fit, Toggle 2D-3D, panel toggles, dark/light mode), Tools (Select/Line/Rectangle/Circle/Arc/Wall/Door/Window/Dimension/Text), Help (About/Updates/Docs). Menu events are broadcast to the frontend via `app.emit("menu", id)`.
- **Frontend (`useMenuBar.ts`)**: New hook + `dispatchMenuEvent` dispatcher. Routes each menu-item ID to the correct `documentStore` action (`undo`, `redo`, `setActiveTool`), custom DOM events (`opencad:toggle-view`, `opencad:show-about`, `opencad:check-updates`), theme toggling (`data-theme` + localStorage), or caller-provided handler callbacks.
- **Tests (`useMenuBar.test.ts`)**: 38 unit tests covering T-DSK-007-01 through T-DSK-007-12 — all passing.

## Test plan

- [x] `T-DSK-007-01`: `edit-undo` calls `store.undo()`
- [x] `T-DSK-007-02`: `edit-redo` calls `store.redo()`
- [x] `T-DSK-007-03`: all 10 tool menu IDs call `setActiveTool(toolName)`
- [x] `T-DSK-007-04`: file menu IDs (new/open/save/save-as/export) call the corresponding handler callback
- [x] `T-DSK-007-05`: import menu IDs call `onImport(format)` for ifc/dwg/pdf/revit/sketchup
- [x] `T-DSK-007-06`: zoom menu items call `onZoom('in'|'out'|'fit')`
- [x] `T-DSK-007-07`: panel toggle IDs call `onTogglePanel('layers'|'properties'|'ai-chat')`
- [x] `T-DSK-007-08`: dark/light mode sets `data-theme` attribute and persists to localStorage
- [x] `T-DSK-007-09`: `view-toggle-2d-3d` dispatches `opencad:toggle-view` CustomEvent
- [x] `T-DSK-007-10`: help menu dispatches `opencad:show-about` and `opencad:check-updates` events
- [x] `T-DSK-007-11`: unknown menu IDs are silently ignored (no throw)
- [x] `T-DSK-007-12`: all handlers are optional — no error when omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)