### PR TITLE
feat(ai): validate generated BIM elements against design rules

### DIFF
--- a/packages/ai/src/generate.ts
+++ b/packages/ai/src/generate.ts
@@ -7,6 +7,8 @@
  * 2-bedroom house template when no API key is provided or the call fails.
  */
 
+import { validateElement, type ValidationResult } from './validation';
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 /** Mirror of DocumentSchema property value (avoid cross-package import in tests). */
@@ -49,6 +51,12 @@ export interface GenerateProjectOptions {
   apiKey?: string; // Anthropic API key (optional — falls back to template)
 }
 
+/** Per-element BIM validation result returned alongside the generated document. */
+export interface ElementValidationSummary {
+  elementId: string;
+  result: ValidationResult;
+}
+
 export interface GenerateProjectResult {
   document: {
     id?: string;
@@ -73,6 +81,8 @@ export interface GenerateProjectResult {
   };
   description: string;
   warnings: string[];
+  /** BIM validation results per element. Empty when no elements were validated. */
+  validation: ElementValidationSummary[];
 }
 
 // ─── System Prompt ────────────────────────────────────────────────────────────
@@ -282,6 +292,43 @@ function isValidDocumentSchema(obj: unknown): obj is GenerateProjectResult['docu
   );
 }
 
+// ─── BIM Validation Helper ────────────────────────────────────────────────────
+
+/**
+ * Run validateElement on every element in the generated document.
+ * The document's WallElement shape is structurally compatible with validateElement's
+ * expected BimElement interface (duck typing).
+ */
+function validateGeneratedDocument(
+  doc: GenerateProjectResult['document'],
+): ElementValidationSummary[] {
+  const elements = Object.values(doc.content?.elements ?? {});
+  if (elements.length === 0) return [];
+
+  const layers = (doc.organization?.layers ?? {}) as Record<
+    string,
+    { name: string; locked: boolean }
+  >;
+
+  const minimalDoc = {
+    organization: { layers },
+    content: {
+      elements: doc.content?.elements as unknown as Record<
+        string,
+        Parameters<typeof validateElement>[0]
+      > ?? {},
+    },
+  };
+
+  return elements.map((el) => ({
+    elementId: el.id,
+    result: validateElement(
+      el as unknown as Parameters<typeof validateElement>[0],
+      minimalDoc,
+    ),
+  }));
+}
+
 // ─── Main Export ──────────────────────────────────────────────────────────────
 
 export async function generateProject(
@@ -299,6 +346,7 @@ export async function generateProject(
       document: doc,
       description: `Fallback 2-bedroom house template (${elementCount} elements). Provide an Anthropic API key to generate a custom floor plan.`,
       warnings,
+      validation: validateGeneratedDocument(doc),
     };
   }
 
@@ -330,6 +378,7 @@ export async function generateProject(
         document: doc,
         description: `Fallback 2-bedroom house template (${Object.keys(doc.content?.elements ?? {}).length} elements).`,
         warnings,
+        validation: validateGeneratedDocument(doc),
       };
     }
 
@@ -342,6 +391,7 @@ export async function generateProject(
         document: doc,
         description: `Fallback 2-bedroom house template.`,
         warnings,
+        validation: validateGeneratedDocument(doc),
       };
     }
 
@@ -373,6 +423,7 @@ export async function generateProject(
       document: doc,
       description: `Fallback 2-bedroom house template (${Object.keys(doc.content?.elements ?? {}).length} elements).`,
       warnings,
+      validation: validateGeneratedDocument(doc),
     };
   }
 
@@ -386,6 +437,7 @@ export async function generateProject(
       document: doc,
       description: `Fallback 2-bedroom house template (${Object.keys(doc.content?.elements ?? {}).length} elements).`,
       warnings,
+      validation: validateGeneratedDocument(doc),
     };
   }
 
@@ -395,9 +447,17 @@ export async function generateProject(
     (e) => (e as WallElement).type === 'wall'
   ).length;
 
+  const validation = validateGeneratedDocument(doc);
+  // Surface BIM errors/warnings in the top-level warnings array for easy display
+  for (const { result } of validation) {
+    for (const err of result.errors) warnings.push(`[BIM Error] ${err}`);
+    for (const warn of result.warnings) warnings.push(`[BIM Warning] ${warn}`);
+  }
+
   return {
     document: doc,
     description: `Generated "${doc.name ?? 'project'}" with ${elementCount} elements (${wallCount} walls).`,
     warnings,
+    validation,
   };
 }

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -30,3 +30,11 @@ export { checkCompliance, applyFix } from './codeCompliance';
 export { IBC_RULES } from './rules/ibc';
 export type { ComplianceReport, Violation } from './codeCompliance';
 export type { Rule } from './rules/ibc';
+
+// BIM element validation (T-AI-005 through T-AI-007)
+export { validateElement } from './validation';
+export type { ValidationResult } from './validation';
+
+// AI project generation with validation
+export { generateProject } from './generate';
+export type { GenerateProjectOptions, GenerateProjectResult, ElementValidationSummary } from './generate';

--- a/packages/ai/src/validation.test.ts
+++ b/packages/ai/src/validation.test.ts
@@ -1,6 +1,6 @@
 /**
  * AI Validation Tests
- * T-AI-002 through T-AI-005, T-AI-010 through T-AI-012, T-AI-020 through T-AI-024
+ * T-AI-002 through T-AI-007, T-AI-010 through T-AI-012, T-AI-020 through T-AI-024
  */
 
 import { describe, it, expect } from 'vitest';
@@ -17,10 +17,12 @@ import {
   getCitationForRule,
   suggestFix,
   runOfflineCompliance,
+  validateElement,
   type Room,
   type FloorPlan,
   type ModelDocument,
   type ComplianceViolation,
+  type ValidationResult,
 } from './validation';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -498,5 +500,218 @@ describe('T-AI-024: Offline Code Compliance', () => {
     const result = runOfflineCompliance(rooms);
     expect(result).not.toBeInstanceOf(Promise);
     expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+// ─── BIM Element Validation Fixtures ─────────────────────────────────────────
+
+type PropValue = { type: 'string' | 'number' | 'boolean' | 'enum' | 'reference'; value: string | number | boolean | string[] };
+
+function makeTestDoc(elements: Record<string, ReturnType<typeof makeTestWall>> = {}) {
+  return {
+    organization: {
+      layers: {
+        'layer-walls': { name: 'Walls', locked: false },
+        'layer-locked': { name: 'Locked Layer', locked: true },
+      },
+    },
+    content: { elements },
+  };
+}
+
+function makeTestWall(id: string, heightMm: number, layerId = 'layer-walls', extraProps: Record<string, PropValue> = {}) {
+  return {
+    id,
+    type: 'wall' as const,
+    layerId,
+    properties: {
+      Height: { type: 'number' as const, value: heightMm },
+      StartX: { type: 'number' as const, value: 0 },
+      StartY: { type: 'number' as const, value: 0 },
+      EndX: { type: 'number' as const, value: 5000 },
+      EndY: { type: 'number' as const, value: 0 },
+      ...extraProps,
+    },
+    boundingBox: {
+      min: { x: 0, y: 0, z: 0 },
+      max: { x: 5000, y: 200, z: heightMm },
+    },
+  };
+}
+
+function makeTestDoor(id: string, x: number, y: number, w: number, h: number, layerId = 'layer-walls') {
+  return {
+    id,
+    type: 'door' as const,
+    layerId,
+    properties: {} as Record<string, PropValue>,
+    boundingBox: {
+      min: { x, y, z: 0 },
+      max: { x: x + w, y: y + h, z: 2100 },
+    },
+  };
+}
+
+function makeTestBeam(id: string, hasStartEnd: boolean, layerId = 'layer-walls') {
+  const props: Record<string, PropValue> = hasStartEnd
+    ? {
+        StartX: { type: 'number', value: 0 },
+        StartY: { type: 'number', value: 0 },
+        EndX: { type: 'number', value: 5000 },
+        EndY: { type: 'number', value: 0 },
+      }
+    : {};
+  return {
+    id,
+    type: 'beam' as const,
+    layerId,
+    properties: props,
+    boundingBox: {
+      min: { x: 0, y: 0, z: 2500 },
+      max: { x: 5000, y: 200, z: 2800 },
+    },
+  };
+}
+
+// ─── T-AI-005: Wall with height=0 fails validation ──────────────────────────��─
+
+describe('T-AI-005: Wall height=0 fails BIM validation', () => {
+  it('should return valid=false for a wall with height=0', () => {
+    const wall = makeTestWall('wall-zero', 0);
+    const doc = makeTestDoc();
+    const result: ValidationResult = validateElement(wall, doc);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.some((e) => e.toLowerCase().includes('height'))).toBe(true);
+  });
+
+  it('should return valid=false for a wall with negative height', () => {
+    const wall = makeTestWall('wall-neg', -100);
+    const doc = makeTestDoc();
+    const result = validateElement(wall, doc);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.toLowerCase().includes('height'))).toBe(true);
+  });
+
+  it('should return no height errors for a wall with positive height', () => {
+    const wall = makeTestWall('wall-ok', 3000);
+    const doc = makeTestDoc();
+    const result = validateElement(wall, doc);
+    expect(result.errors.filter((e) => e.toLowerCase().includes('height'))).toHaveLength(0);
+  });
+});
+
+// ─── T-AI-006: Door outside any wall gets a warning ──────────────────────────
+
+describe('T-AI-006: Door outside any wall gets a warning', () => {
+  it('should warn when a door is not within any wall bounding box', () => {
+    const doorFar = makeTestDoor('door-far', 10000, 10000, 900, 200);
+    const doc = makeTestDoc({ 'wall-1': makeTestWall('wall-1', 3000) });
+    const result = validateElement(doorFar, doc);
+    expect(result.warnings.some((w) => w.toLowerCase().includes('wall'))).toBe(true);
+  });
+
+  it('should not warn when door is contained within a wall bounding box', () => {
+    // Wall bbox: x:[0..5000], y:[0..200], z:[0..3000]
+    // Door must be fully inside: x:[500..1400], y:[0..200]
+    const door = makeTestDoor('door-in', 500, 0, 900, 200);
+    const wall = makeTestWall('wall-1', 3000);
+    const doc = makeTestDoc({ 'wall-1': wall });
+    const result = validateElement(door, doc);
+    expect(result.warnings.filter((w) => w.toLowerCase().includes('wall'))).toHaveLength(0);
+  });
+
+  it('should warn when no walls exist in the document', () => {
+    const door = makeTestDoor('door-1', 0, 0, 900, 200);
+    const doc = makeTestDoc(); // no walls
+    const result = validateElement(door, doc);
+    expect(result.warnings.some((w) => w.toLowerCase().includes('wall'))).toBe(true);
+  });
+});
+
+// ─── T-AI-007: Valid wall passes all checks ───────────────────────────────────
+
+describe('T-AI-007: Valid wall passes all BIM checks', () => {
+  it('should return valid=true and no errors for a well-formed wall', () => {
+    const wall = makeTestWall('wall-good', 3000);
+    const doc = makeTestDoc();
+    const result = validateElement(wall, doc);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should produce no errors and no warnings for a standard unlocked wall', () => {
+    const wall = makeTestWall('wall-good', 2700);
+    const doc = makeTestDoc();
+    const result = validateElement(wall, doc);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('ValidationResult type has valid, errors, and warnings fields', () => {
+    const wall = makeTestWall('w1', 3000);
+    const doc = makeTestDoc();
+    const result = validateElement(wall, doc);
+    expect(typeof result.valid).toBe('boolean');
+    expect(Array.isArray(result.errors)).toBe(true);
+    expect(Array.isArray(result.warnings)).toBe(true);
+  });
+});
+
+// ─── Additional BIM validation rules ─────────────────────────────────────────
+
+describe('BIM validation: locked layer warning', () => {
+  it('should warn when an element is placed on a locked layer', () => {
+    const wall = makeTestWall('wall-locked', 3000, 'layer-locked');
+    const doc = makeTestDoc();
+    const result = validateElement(wall, doc);
+    expect(result.warnings.some((w) => w.toLowerCase().includes('lock'))).toBe(true);
+  });
+
+  it('should not warn for an element on an unlocked layer', () => {
+    const wall = makeTestWall('wall-unlocked', 3000, 'layer-walls');
+    const doc = makeTestDoc();
+    const result = validateElement(wall, doc);
+    expect(result.warnings.filter((w) => w.toLowerCase().includes('lock'))).toHaveLength(0);
+  });
+});
+
+describe('BIM validation: overlapping elements of same type', () => {
+  it('should warn when two walls of same type overlap on same layer', () => {
+    const wall1 = makeTestWall('w1', 3000, 'layer-walls');
+    const wall2 = makeTestWall('w2', 3000, 'layer-walls'); // same bbox
+    const doc = makeTestDoc({ w1: wall1, w2: wall2 });
+    const result = validateElement(wall1, doc);
+    expect(result.warnings.some((w) => w.toLowerCase().includes('overlap'))).toBe(true);
+  });
+
+  it('should not warn when walls are on different layers', () => {
+    const wall1 = makeTestWall('w1', 3000, 'layer-walls');
+    const wall2 = makeTestWall('w2', 3000, 'layer-locked');
+    const doc = makeTestDoc({ w1: wall1, w2: wall2 });
+    const result = validateElement(wall1, doc);
+    expect(result.warnings.filter((w) => w.toLowerCase().includes('overlap'))).toHaveLength(0);
+  });
+});
+
+describe('BIM validation: beam must have start/end points', () => {
+  it('should error when beam has no start/end point properties', () => {
+    const beam = makeTestBeam('beam-1', false);
+    const doc = makeTestDoc();
+    const result = validateElement(beam, doc);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) =>
+      e.toLowerCase().includes('start') || e.toLowerCase().includes('end') || e.toLowerCase().includes('span')
+    )).toBe(true);
+  });
+
+  it('should pass when beam has start and end point properties', () => {
+    const beam = makeTestBeam('beam-ok', true);
+    const doc = makeTestDoc();
+    const result = validateElement(beam, doc);
+    expect(result.errors.filter((e) =>
+      e.toLowerCase().includes('span') ||
+      (e.toLowerCase().includes('start') && e.toLowerCase().includes('end'))
+    )).toHaveLength(0);
   });
 });

--- a/packages/ai/src/validation.ts
+++ b/packages/ai/src/validation.ts
@@ -374,3 +374,131 @@ export function runOfflineCompliance(rooms: Room[]): ComplianceViolation[] {
   // Fully deterministic, synchronous — same as IBC rules, no network
   return runIBCCompliance(rooms);
 }
+
+// ─── T-AI-005/006/007: BIM Element Validation ────────────────────────────────
+
+/**
+ * Result of validating a single BIM element against document rules.
+ * - `valid`: false if any hard errors are present
+ * - `errors`: blocking rule violations (element should not be added)
+ * - `warnings`: non-blocking advisory notices
+ */
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+// Minimal BIM element bounding box shape (avoids importing full ElementSchema in this file)
+interface BimBBox {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+interface BimElement {
+  id: string;
+  type: string;
+  layerId: string;
+  properties: Record<string, { type: string; value: string | number | boolean | string[] }>;
+  boundingBox: BimBBox;
+}
+
+interface BimDoc {
+  organization: {
+    layers: Record<string, { locked: boolean; name: string }>;
+  };
+  content: {
+    elements: Record<string, BimElement>;
+  };
+}
+
+/**
+ * Validate a single BIM element against the rules of the given document.
+ *
+ * Rules checked (T-AI-005, T-AI-006, T-AI-007):
+ *   - Walls must have Height > 0
+ *   - Doors/Windows must be contained within at least one wall bounding box
+ *   - Beams must have both StartX/StartY and EndX/EndY properties
+ *   - Elements on locked layers → warning
+ *   - Overlapping elements of same type on same layer → warning
+ */
+export function validateElement(element: BimElement, doc: BimDoc): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // ── Rule: locked layer warning ────────────────────────────────────────────
+  const layer = doc.organization.layers[element.layerId];
+  if (layer?.locked) {
+    warnings.push(`Element "${element.id}" is on locked layer "${layer.name}".`);
+  }
+
+  // ── Rule: wall must have positive height ──────────────────────────────────
+  if (element.type === 'wall') {
+    const heightProp = element.properties['Height'];
+    const height = typeof heightProp?.value === 'number' ? heightProp.value : null;
+    if (height === null || height <= 0) {
+      errors.push(
+        `Wall "${element.id}" must have a positive Height (got ${height ?? 'none'}).`,
+      );
+    }
+  }
+
+  // ── Rule: door/window must be contained within a wall ────────────────────
+  if (element.type === 'door' || element.type === 'window') {
+    const walls = Object.values(doc.content.elements).filter((e) => e.type === 'wall');
+    const contained = walls.some((wall) =>
+      _bim3DContains(wall.boundingBox, element.boundingBox),
+    );
+    if (!contained) {
+      const kind = element.type === 'door' ? 'Door' : 'Window';
+      warnings.push(`${kind} "${element.id}" is not contained within any wall.`);
+    }
+  }
+
+  // ── Rule: beam must have start/end points ────────────────────────────────
+  if (element.type === 'beam') {
+    const hasStart = 'StartX' in element.properties && 'StartY' in element.properties;
+    const hasEnd = 'EndX' in element.properties && 'EndY' in element.properties;
+    if (!hasStart || !hasEnd) {
+      errors.push(
+        `Beam "${element.id}" must have start and end point properties (StartX/StartY and EndX/EndY) to span between supports.`,
+      );
+    }
+  }
+
+  // ── Rule: overlapping same-type elements on same layer → warning ──────────
+  const sameTypeAndLayer = Object.values(doc.content.elements).filter(
+    (e) =>
+      e.id !== element.id &&
+      e.type === element.type &&
+      e.layerId === element.layerId,
+  );
+  for (const other of sameTypeAndLayer) {
+    if (_bim3DOverlaps(element.boundingBox, other.boundingBox)) {
+      warnings.push(
+        `Element "${element.id}" overlaps with "${other.id}" (same type "${element.type}" on layer "${element.layerId}").`,
+      );
+      break; // one warning per element is sufficient
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+function _bim3DOverlaps(a: BimBBox, b: BimBBox): boolean {
+  return (
+    a.min.x < b.max.x &&
+    a.max.x > b.min.x &&
+    a.min.y < b.max.y &&
+    a.max.y > b.min.y
+  );
+}
+
+function _bim3DContains(outer: BimBBox, inner: BimBBox): boolean {
+  return (
+    inner.min.x >= outer.min.x &&
+    inner.max.x <= outer.max.x &&
+    inner.min.y >= outer.min.y &&
+    inner.max.y <= outer.max.y
+  );
+}

--- a/packages/app/src/components/AIChatPanel.tsx
+++ b/packages/app/src/components/AIChatPanel.tsx
@@ -1,7 +1,50 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Bot, User, X, Settings } from 'lucide-react';
-import { FloorPlanGenerator } from '@opencad/ai';
+import { FloorPlanGenerator, validateElement } from '@opencad/ai';
 import { useDocumentStore } from '../stores/documentStore';
+import type { DocumentSchema } from '@opencad/document';
+
+/**
+ * Run BIM validation on all elements in a generated schema.
+ * Returns a human-readable summary of errors and warnings, or null if all pass.
+ */
+function buildValidationSummary(schema: DocumentSchema): string | null {
+  const layers = schema.organization.layers as Record<string, { name: string; locked: boolean }>;
+  const elements = Object.values(schema.content.elements);
+  if (elements.length === 0) return null;
+
+  const minimalDoc = {
+    organization: { layers },
+    content: {
+      elements: schema.content.elements as Parameters<typeof validateElement>[1]['content']['elements'],
+    },
+  };
+
+  const allErrors: string[] = [];
+  const allWarnings: string[] = [];
+
+  for (const el of elements) {
+    const result = validateElement(
+      el as Parameters<typeof validateElement>[0],
+      minimalDoc,
+    );
+    allErrors.push(...result.errors);
+    allWarnings.push(...result.warnings);
+  }
+
+  if (allErrors.length === 0 && allWarnings.length === 0) return null;
+
+  const lines: string[] = [];
+  if (allErrors.length > 0) {
+    lines.push(`BIM Validation — ${allErrors.length} error(s):`);
+    allErrors.forEach((e) => lines.push(`  • ${e}`));
+  }
+  if (allWarnings.length > 0) {
+    lines.push(`BIM Validation — ${allWarnings.length} warning(s):`);
+    allWarnings.forEach((w) => lines.push(`  ⚠ ${w}`));
+  }
+  return lines.join('\n');
+}
 
 /** Returns true when the message looks like a floor-plan generation request. */
 function isFloorPlanRequest(text: string): boolean {
@@ -108,10 +151,15 @@ export function AIChatPanel({ onClose }: AIChatPanelProps) {
       try {
         const schema = await generator.generateFloorPlan(text);
         loadDocumentSchema(schema);
+        const validationSummary = buildValidationSummary(schema);
+        const baseContent = 'Floor plan generated and loaded into the canvas. Switch to 2D view to see the layout.';
+        const content = validationSummary
+          ? `${baseContent}\n\n${validationSummary}`
+          : baseContent;
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId
-              ? { ...m, content: 'Floor plan generated and loaded into the canvas. Switch to 2D view to see the layout.' }
+              ? { ...m, content }
               : m
           )
         );


### PR DESCRIPTION
## Summary

- Adds `validateElement(element, doc): ValidationResult` to `packages/ai/src/validation.ts` with five BIM rules: wall height > 0, door/window bounding-box containment within a wall, beam start/end point properties, locked-layer warning, and same-type overlap warning
- Integrates validation into `generateProject` — each generated element is validated and results are returned in a new `validation: ElementValidationSummary[]` field; BIM errors/warnings are also surfaced in the top-level `warnings` array
- Exports `validateElement`, `ValidationResult`, `generateProject`, `GenerateProjectResult`, and `ElementValidationSummary` from the package index
- Updates `AIChatPanel` to display BIM validation errors and warnings inline in the chat response after floor plan generation

## Tests

Tests written first (TDD Red → Green):

- `T-AI-005`: wall with `Height=0` fails validation with an error
- `T-AI-006`: door not contained in any wall's bounding box produces a warning
- `T-AI-007`: valid wall with positive height passes all checks with no errors
- Additional coverage: locked-layer warning, same-type overlap warning, beam missing start/end

**Verification:**
```bash
pnpm --filter=@opencad/ai test:unit     # 231 passed
pnpm --filter=@opencad/ai typecheck     # clean
pnpm --filter=@opencad/app typecheck    # clean
```

## Test plan

- [ ] Run `pnpm --filter=@opencad/ai test:unit` and confirm 231 tests pass
- [ ] Run `pnpm --filter=@opencad/ai typecheck` — expect no errors
- [ ] Run `pnpm --filter=@opencad/app typecheck` — expect no errors
- [ ] Manually test in AIChatPanel: generate a floor plan, observe validation summary appended to success message if BIM issues exist

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)