### PR TITLE
feat(billing): T-PAY-001/002 billing dashboard panel in settings

### DIFF
--- a/packages/app/src/AppLayout.tsx
+++ b/packages/app/src/AppLayout.tsx
@@ -53,6 +53,7 @@ import { AuthModal } from './components/AuthModal';
 import { APIKeyPanel } from './components/APIKeyPanel';
 import { PermissionsPanel } from './components/PermissionsPanel';
 import { SSOSettingsPanel } from './components/SSOSettingsPanel';
+import { BillingPanel } from './components/BillingPanel';
 import { MobileViewer } from './components/MobileViewer';
 import { FeedbackWidget } from './components/FeedbackWidget';
 import { PanelResizer } from './components/PanelResizer';
@@ -115,7 +116,7 @@ export function AppLayout() {
   const [showAuth, setShowAuth] = useState<'login' | 'register' | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
-  const [settingsTab, setSettingsTab] = useState<'apikeys' | 'permissions' | 'sso'>('apikeys');
+  const [settingsTab, setSettingsTab] = useState<'apikeys' | 'permissions' | 'sso' | 'billing'>('apikeys');
   const [rightPanelTab, setRightPanelTab] = useLocalStorage<RightPanelTab>('opencad-rightPanelTab', 'layers');
   const [currentFilePath, setCurrentFilePath] = useLocalStorage<string | null>('opencad-currentFilePath', null);
 
@@ -409,11 +410,13 @@ export function AppLayout() {
               <button className={`settings-tab-btn${settingsTab === 'apikeys' ? ' active' : ''}`} onClick={() => setSettingsTab('apikeys')}>API Keys</button>
               <button className={`settings-tab-btn${settingsTab === 'permissions' ? ' active' : ''}`} onClick={() => setSettingsTab('permissions')}>Permissions</button>
               <button className={`settings-tab-btn${settingsTab === 'sso' ? ' active' : ''}`} onClick={() => setSettingsTab('sso')}>SSO</button>
+              <button className={`settings-tab-btn${settingsTab === 'billing' ? ' active' : ''}`} onClick={() => setSettingsTab('billing')}>Billing</button>
             </div>
             <div className="settings-content">
               {settingsTab === 'apikeys' && <APIKeyPanel />}
               {settingsTab === 'permissions' && <PermissionsPanel />}
               {settingsTab === 'sso' && <SSOSettingsPanel />}
+              {settingsTab === 'billing' && <BillingPanel />}
             </div>
           </div>
         </div>

--- a/packages/app/src/components/BillingPanel.test.tsx
+++ b/packages/app/src/components/BillingPanel.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * T-PAY-001 / T-PAY-002: BillingPanel component tests
+ *
+ * Tests T-PAY-001-001 through T-PAY-001-007 (plan badge, trial countdown, upgrade):
+ * - T-PAY-001-001: Renders current plan badge — Trial
+ * - T-PAY-001-002: Renders current plan badge — Pro
+ * - T-PAY-001-003: Trial countdown shows days remaining when on trial
+ * - T-PAY-001-004: Trial countdown is hidden when not on trial
+ * - T-PAY-001-005: Upgrade button present and links to pricing
+ * - T-PAY-001-006: Invoice history table renders mock rows
+ * - T-PAY-001-007: Cancel subscription button present with confirmation
+ *
+ * Tests T-PAY-002-001 through T-PAY-002-003 (plan tiers: Starter, Enterprise):
+ * - T-PAY-002-001: Renders Starter plan badge
+ * - T-PAY-002-002: Renders Enterprise plan badge
+ * - T-PAY-002-003: Cancel button absent on free / trial tier
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BillingPanel } from './BillingPanel';
+
+const mockUseSubscription = vi.fn();
+
+vi.mock('../hooks/useSubscription', () => ({
+  useSubscription: () => mockUseSubscription(),
+}));
+
+// Mock window.open for upgrade button
+const mockWindowOpen = vi.fn();
+
+describe('T-PAY-001: BillingPanel — plan badge and trial countdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'open', { value: mockWindowOpen, writable: true });
+    // Default: trial tier, 7 days remaining (validUntil = now + 7 days in ms)
+    const sevenDaysMs = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    mockUseSubscription.mockReturnValue({
+      tier: 'trial',
+      validUntil: sevenDaysMs,
+      isLoading: false,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: vi.fn(),
+    });
+  });
+
+  it('T-PAY-001-001: renders current plan badge for trial tier', () => {
+    render(<BillingPanel />);
+    expect(screen.getByTestId('plan-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent(/trial/i);
+  });
+
+  it('T-PAY-001-002: renders current plan badge for pro tier', () => {
+    mockUseSubscription.mockReturnValue({
+      tier: 'pro',
+      validUntil: null,
+      isLoading: false,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: vi.fn(),
+    });
+    render(<BillingPanel />);
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent(/pro/i);
+  });
+
+  it('T-PAY-001-003: trial countdown shows days remaining when on trial', () => {
+    render(<BillingPanel />);
+    expect(screen.getByTestId('trial-countdown')).toBeInTheDocument();
+    expect(screen.getByTestId('trial-countdown')).toHaveTextContent(/7.*day/i);
+  });
+
+  it('T-PAY-001-004: trial countdown is hidden when not on trial', () => {
+    mockUseSubscription.mockReturnValue({
+      tier: 'pro',
+      validUntil: null,
+      isLoading: false,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: vi.fn(),
+    });
+    render(<BillingPanel />);
+    expect(screen.queryByTestId('trial-countdown')).not.toBeInTheDocument();
+  });
+
+  it('T-PAY-001-005: upgrade button is present', () => {
+    render(<BillingPanel />);
+    expect(screen.getByTestId('upgrade-btn')).toBeInTheDocument();
+  });
+
+  it('T-PAY-001-005b: clicking upgrade opens pricing page', () => {
+    render(<BillingPanel />);
+    fireEvent.click(screen.getByTestId('upgrade-btn'));
+    expect(mockWindowOpen).toHaveBeenCalledWith('https://opencad.archi/pricing', '_blank');
+  });
+
+  it('T-PAY-001-006: invoice history table renders mock rows', () => {
+    render(<BillingPanel />);
+    expect(screen.getByTestId('invoice-table')).toBeInTheDocument();
+    // Should have at least one invoice row
+    expect(screen.getAllByTestId('invoice-row').length).toBeGreaterThan(0);
+  });
+
+  it('T-PAY-001-006b: invoice rows show date, amount, status', () => {
+    render(<BillingPanel />);
+    const rows = screen.getAllByTestId('invoice-row');
+    // First row should contain amount and status info
+    expect(rows[0]).toBeInTheDocument();
+    // There should be a download/PDF link in each row
+    expect(screen.getAllByTestId('invoice-pdf-link').length).toBeGreaterThan(0);
+  });
+
+  it('T-PAY-001-007: cancel subscription button is present for trial/paid tiers', () => {
+    render(<BillingPanel />);
+    expect(screen.getByTestId('cancel-subscription-btn')).toBeInTheDocument();
+  });
+
+  it('T-PAY-001-007b: cancel button shows confirmation dialog', () => {
+    render(<BillingPanel />);
+    fireEvent.click(screen.getByTestId('cancel-subscription-btn'));
+    expect(screen.getByTestId('cancel-confirm-dialog')).toBeInTheDocument();
+  });
+
+  it('T-PAY-001-007c: confirming cancel dialog calls openPortal', () => {
+    const mockOpenPortal = vi.fn().mockResolvedValue(undefined);
+    mockUseSubscription.mockReturnValue({
+      tier: 'pro',
+      validUntil: null,
+      isLoading: false,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: mockOpenPortal,
+    });
+    render(<BillingPanel />);
+    fireEvent.click(screen.getByTestId('cancel-subscription-btn'));
+    fireEvent.click(screen.getByTestId('cancel-confirm-yes'));
+    expect(mockOpenPortal).toHaveBeenCalled();
+  });
+
+  it('T-PAY-001-007d: dismissing cancel dialog hides it', () => {
+    render(<BillingPanel />);
+    fireEvent.click(screen.getByTestId('cancel-subscription-btn'));
+    expect(screen.getByTestId('cancel-confirm-dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('cancel-confirm-no'));
+    expect(screen.queryByTestId('cancel-confirm-dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('T-PAY-002: BillingPanel — plan tier badges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'open', { value: mockWindowOpen, writable: true });
+  });
+
+  it('T-PAY-002-001: renders Starter plan badge', () => {
+    mockUseSubscription.mockReturnValue({
+      tier: 'free',
+      validUntil: null,
+      isLoading: false,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: vi.fn(),
+    });
+    render(<BillingPanel />);
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent(/free/i);
+  });
+
+  it('T-PAY-002-002: renders Business plan badge', () => {
+    mockUseSubscription.mockReturnValue({
+      tier: 'business',
+      validUntil: null,
+      isLoading: false,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: vi.fn(),
+    });
+    render(<BillingPanel />);
+    expect(screen.getByTestId('plan-badge')).toHaveTextContent(/business/i);
+  });
+
+  it('T-PAY-002-003: cancel button is absent on free tier', () => {
+    mockUseSubscription.mockReturnValue({
+      tier: 'free',
+      validUntil: null,
+      isLoading: false,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: vi.fn(),
+    });
+    render(<BillingPanel />);
+    expect(screen.queryByTestId('cancel-subscription-btn')).not.toBeInTheDocument();
+  });
+
+  it('T-PAY-002-004: shows loading state while subscription is loading', () => {
+    mockUseSubscription.mockReturnValue({
+      tier: 'free',
+      validUntil: null,
+      isLoading: true,
+      upgrade: vi.fn(),
+      startCheckout: vi.fn(),
+      openPortal: vi.fn(),
+    });
+    render(<BillingPanel />);
+    expect(screen.getByTestId('billing-loading')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/BillingPanel.tsx
+++ b/packages/app/src/components/BillingPanel.tsx
@@ -1,0 +1,222 @@
+/**
+ * T-PAY-001 / T-PAY-002: Billing Dashboard panel.
+ *
+ * Shown inside the settings modal under the "billing" tab.
+ *
+ * Features:
+ * - Current plan badge (Free / Trial / Pro / Business)
+ * - Trial days remaining countdown (only on trial tier)
+ * - Upgrade button → opens https://opencad.archi/pricing
+ * - Invoice history table (mock data)
+ * - Cancel subscription button with confirmation dialog
+ *   (hidden on free tier; routes through Stripe billing portal)
+ *
+ * data-testids:
+ *   billing-loading           — loading skeleton
+ *   plan-badge                — current plan label
+ *   trial-countdown           — "X days remaining" (trial only)
+ *   upgrade-btn               — opens pricing page
+ *   invoice-table             — invoice <table>
+ *   invoice-row               — each <tr> for an invoice
+ *   invoice-pdf-link          — PDF download anchor per row
+ *   cancel-subscription-btn   — opens cancel confirm dialog
+ *   cancel-confirm-dialog     — confirmation dialog
+ *   cancel-confirm-yes        — confirm cancel button
+ *   cancel-confirm-no         — dismiss button
+ */
+import React, { useState } from 'react';
+import { useSubscription } from '../hooks/useSubscription';
+import type { SubscriptionTier } from '../lib/serverApi';
+
+// ── Invoice mock data ────────────────────────────────────────────────────────
+
+export interface InvoiceRow {
+  id: string;
+  date: string;
+  amount: string;
+  status: 'paid' | 'pending' | 'failed';
+  pdf: string;
+}
+
+const MOCK_INVOICES: InvoiceRow[] = [
+  { id: 'inv-001', date: '2026-03-01', amount: '£29.00', status: 'paid', pdf: 'https://opencad.archi/invoices/inv-001.pdf' },
+  { id: 'inv-002', date: '2026-02-01', amount: '£29.00', status: 'paid', pdf: 'https://opencad.archi/invoices/inv-002.pdf' },
+  { id: 'inv-003', date: '2026-01-01', amount: '£29.00', status: 'paid', pdf: 'https://opencad.archi/invoices/inv-003.pdf' },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const PLAN_LABELS: Record<SubscriptionTier | 'trial', string> = {
+  free: 'Free',
+  pro: 'Pro',
+  business: 'Business',
+  trial: 'Trial',
+};
+
+/** Returns days remaining until validUntil epoch (ms). Minimum 0. */
+function daysRemaining(validUntil: number): number {
+  const diff = validUntil - Date.now();
+  return Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
+}
+
+/** Tiers that have an active paid/trial subscription worth cancelling. */
+const CANCELLABLE_TIERS = new Set<SubscriptionTier | 'trial'>(['trial', 'pro', 'business']);
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function BillingPanel(): React.ReactElement {
+  const { tier, validUntil, isLoading, openPortal } = useSubscription();
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+
+  if (isLoading) {
+    return (
+      <div className="billing-panel" data-testid="billing-loading">
+        <p className="billing-loading-text">Loading billing information…</p>
+      </div>
+    );
+  }
+
+  // Determine the effective plan label. The authStore uses 'trial' but
+  // SubscriptionTier only has 'free' | 'pro' | 'business'. Cast defensively.
+  const effectiveTier = tier as SubscriptionTier | 'trial';
+  const planLabel = PLAN_LABELS[effectiveTier] ?? String(effectiveTier);
+  const isTrial = effectiveTier === 'trial';
+  const canCancel = CANCELLABLE_TIERS.has(effectiveTier);
+
+  const handleUpgrade = (): void => {
+    window.open('https://opencad.archi/pricing', '_blank');
+  };
+
+  const handleCancelConfirm = (): void => {
+    setShowCancelDialog(false);
+    void openPortal();
+  };
+
+  return (
+    <div className="billing-panel">
+      {/* ── Plan badge ─────────────────────────────────────────────────────── */}
+      <section className="billing-section billing-plan-section">
+        <h3 className="billing-section-title">Current Plan</h3>
+        <div className="billing-plan-row">
+          <span
+            className={`billing-plan-badge billing-plan-badge--${effectiveTier}`}
+            data-testid="plan-badge"
+          >
+            {planLabel}
+          </span>
+
+          {isTrial && validUntil !== null && (
+            <span className="billing-trial-countdown" data-testid="trial-countdown">
+              {daysRemaining(validUntil)} days remaining in trial
+            </span>
+          )}
+        </div>
+
+        <button
+          className="billing-upgrade-btn"
+          data-testid="upgrade-btn"
+          onClick={handleUpgrade}
+          type="button"
+        >
+          Upgrade Plan
+        </button>
+      </section>
+
+      {/* ── Invoice history ─────────────────────────────────────────────────── */}
+      <section className="billing-section billing-invoices-section">
+        <h3 className="billing-section-title">Invoice History</h3>
+        <table className="billing-invoice-table" data-testid="invoice-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Amount</th>
+              <th>Status</th>
+              <th>PDF</th>
+            </tr>
+          </thead>
+          <tbody>
+            {MOCK_INVOICES.map((inv) => (
+              <tr key={inv.id} data-testid="invoice-row">
+                <td>{inv.date}</td>
+                <td>{inv.amount}</td>
+                <td>
+                  <span className={`invoice-status invoice-status--${inv.status}`}>
+                    {inv.status}
+                  </span>
+                </td>
+                <td>
+                  <a
+                    href={inv.pdf}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="invoice-pdf-link"
+                    data-testid="invoice-pdf-link"
+                    aria-label={`Download invoice ${inv.id}`}
+                  >
+                    Download
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      {/* ── Cancel subscription ─────────────────────────────────────────────── */}
+      {canCancel && (
+        <section className="billing-section billing-cancel-section">
+          <h3 className="billing-section-title">Cancel Subscription</h3>
+          <p className="billing-cancel-description">
+            You can cancel your subscription at any time. You will retain access until the
+            end of the current billing period.
+          </p>
+          <button
+            className="billing-cancel-btn"
+            data-testid="cancel-subscription-btn"
+            onClick={() => setShowCancelDialog(true)}
+            type="button"
+          >
+            Cancel Subscription
+          </button>
+        </section>
+      )}
+
+      {/* ── Cancel confirmation dialog ──────────────────────────────────────── */}
+      {showCancelDialog && (
+        <div
+          className="billing-cancel-dialog-overlay"
+          data-testid="cancel-confirm-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Cancel subscription confirmation"
+        >
+          <div className="billing-cancel-dialog">
+            <h4 className="billing-cancel-dialog-title">Cancel subscription?</h4>
+            <p className="billing-cancel-dialog-body">
+              Are you sure you want to cancel? Your plan will stay active until the end of
+              the billing period.
+            </p>
+            <div className="billing-cancel-dialog-actions">
+              <button
+                className="billing-cancel-confirm-yes"
+                data-testid="cancel-confirm-yes"
+                onClick={handleCancelConfirm}
+                type="button"
+              >
+                Yes, cancel
+              </button>
+              <button
+                className="billing-cancel-confirm-no"
+                data-testid="cancel-confirm-no"
+                onClick={() => setShowCancelDialog(false)}
+                type="button"
+              >
+                Keep my plan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `BillingPanel` component (`packages/app/src/components/BillingPanel.tsx`) with plan badge, trial days remaining countdown, upgrade button, mock invoice history table, and cancel subscription dialog
- Add `BillingPanel.test.tsx` with 16 tests covering T-PAY-001 and T-PAY-002 test IDs
- Wire `BillingPanel` into `AppLayout.tsx` settings modal as the `billing` tab (alongside existing API Keys / Permissions / SSO tabs)

## What was built

**`BillingPanel.tsx`** renders:
- `data-testid="plan-badge"` — current plan label (Free / Trial / Pro / Business)
- `data-testid="trial-countdown"` — days remaining, shown only on trial tier
- `data-testid="upgrade-btn"` — opens `https://opencad.archi/pricing` in new tab via `window.open`
- `data-testid="invoice-table"` / `invoice-row` / `invoice-pdf-link` — mock invoice history table (3 rows)
- `data-testid="cancel-subscription-btn"` — visible for trial/pro/business tiers only
- `data-testid="cancel-confirm-dialog"` / `cancel-confirm-yes` / `cancel-confirm-no` — confirmation dialog; confirming routes through `openPortal()` (Stripe billing portal)
- `data-testid="billing-loading"` — loading skeleton while `useSubscription` fetches

**`AppLayout.tsx`** changes:
- Import `BillingPanel`
- `settingsTab` type extended to include `'billing'`
- New "Billing" tab button added to the settings modal tab bar
- `{settingsTab === 'billing' && <BillingPanel />}` wired into settings content

## Test plan

- [x] `T-PAY-001-001`: trial tier renders plan badge with "Trial"
- [x] `T-PAY-001-002`: pro tier renders plan badge with "Pro"
- [x] `T-PAY-001-003`: trial countdown shows correct days remaining
- [x] `T-PAY-001-004`: countdown hidden on non-trial tiers
- [x] `T-PAY-001-005`: upgrade button present and calls `window.open('https://opencad.archi/pricing', '_blank')`
- [x] `T-PAY-001-006`: invoice table renders mock rows with PDF links
- [x] `T-PAY-001-007`: cancel button present for trial/paid tiers; confirmation dialog works; cancel confirmed calls `openPortal()`; cancel dismissed hides dialog
- [x] `T-PAY-002-001`: free tier badge
- [x] `T-PAY-002-002`: business tier badge
- [x] `T-PAY-002-003`: cancel button absent on free tier
- [x] `T-PAY-002-004`: loading state renders `billing-loading` testid

All 16 tests pass. Full suite: 137 test files / 1819 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)