### PR TITLE
feat(app): T-DSK-012/T-HIST-001/T-REVIEW-001 auto-update, change history, review workflow

### DIFF
--- a/packages/app/src/AppLayout.tsx
+++ b/packages/app/src/AppLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import {
-  FolderOpen, FileDown, Bot, Home, Sun, Moon, PanelLeft, PanelRight,
+  FolderOpen, FileDown, Bot, Home, Sun, Moon, PanelLeft, PanelRight, History, GitPullRequest,
   Layers, Settings2, Table2, LayoutDashboard, AlertTriangle, Camera, Sheet,
   MessageSquareWarning, Package, MessageCircle, Leaf, DollarSign, Palette,
   Stamp, Scissors, SunMedium, MapPin, FileText, Image, Store, Wind, User, Settings, Shield,
@@ -50,6 +50,9 @@ import { WindAnalysisPanel } from './components/WindAnalysisPanel';
 import { SplitViewport } from './components/SplitViewport';
 import { PlacementPanel } from './components/PlacementPanel';
 import { AuthModal } from './components/AuthModal';
+import { VersionHistoryPanel } from './components/VersionHistoryPanel';
+import { ReviewPanel } from './components/ReviewPanel';
+import { UpdateBanner } from './components/UpdateBanner';
 import { APIKeyPanel } from './components/APIKeyPanel';
 import { PermissionsPanel } from './components/PermissionsPanel';
 import { SSOSettingsPanel } from './components/SSOSettingsPanel';
@@ -57,13 +60,15 @@ import { MobileViewer } from './components/MobileViewer';
 import { FeedbackWidget } from './components/FeedbackWidget';
 import { PanelResizer } from './components/PanelResizer';
 import { AdminPanel } from './components/AdminPanel';
-import { isTauri, openFile, saveFile, saveFileDialog, openFileDialog, onFileDrop, tauriToggleMaximize } from './hooks/useTauri';
+import { isTauri, openFile, saveFile, saveFileDialog, openFileDialog, onFileDrop, tauriToggleMaximize, checkForUpdates } from './hooks/useTauri';
+import type { TauriUpdateInfo } from './hooks/useTauri';
 import './styles/app.css';
 
 type RightPanelTab =
   | 'layers' | 'properties' | 'schedule' | 'spaces' | 'clash' | 'render' | 'sheets'
   | 'bcf' | 'materials' | 'comments' | 'carbon' | 'cost' | 'hatch' | 'symbols'
-  | 'shadow' | 'section' | 'site' | 'specs' | 'photo' | 'marketplace' | 'wind' | 'admin';
+  | 'shadow' | 'section' | 'site' | 'specs' | 'photo' | 'marketplace' | 'wind' | 'admin'
+  | 'history' | 'review';
 
 const RIGHT_PANEL_TABS: { id: RightPanelTab; title: string; icon: React.ReactNode }[] = [
   { id: 'layers',      title: 'Layers',           icon: <Layers size={16} strokeWidth={2} /> },
@@ -88,6 +93,8 @@ const RIGHT_PANEL_TABS: { id: RightPanelTab; title: string; icon: React.ReactNod
   { id: 'marketplace', title: 'Marketplace',        icon: <Store size={16} strokeWidth={2} /> },
   { id: 'wind',        title: 'Wind Analysis',      icon: <Wind size={16} strokeWidth={2} /> },
   { id: 'admin',       title: 'Admin',              icon: <Shield size={16} strokeWidth={2} /> },
+  { id: 'history',     title: 'History',            icon: <History size={16} strokeWidth={2} /> },
+  { id: 'review',      title: 'Review',             icon: <GitPullRequest size={16} strokeWidth={2} /> },
 ];
 
 export function AppLayout() {
@@ -118,6 +125,7 @@ export function AppLayout() {
   const [settingsTab, setSettingsTab] = useState<'apikeys' | 'permissions' | 'sso'>('apikeys');
   const [rightPanelTab, setRightPanelTab] = useLocalStorage<RightPanelTab>('opencad-rightPanelTab', 'layers');
   const [currentFilePath, setCurrentFilePath] = useLocalStorage<string | null>('opencad-currentFilePath', null);
+  const [tauriUpdateInfo, setTauriUpdateInfo] = React.useState<TauriUpdateInfo | null>(null);
 
   const handleNativeSave = useCallback(async (): Promise<void> => {
     if (!doc) return;
@@ -194,6 +202,13 @@ export function AppLayout() {
     });
     return unlisten;
   }, [loadDocumentSchema, setCurrentFilePath]);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    void checkForUpdates().then((info) => {
+      if (info) setTauriUpdateInfo(info);
+    });
+  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -289,6 +304,9 @@ export function AppLayout() {
         </header>
       )}
 
+      {tauriUpdateInfo && (
+        <UpdateBanner info={tauriUpdateInfo} onDismiss={() => setTauriUpdateInfo(null)} />
+      )}
       <div className="app-body">
         <aside ref={leftPanelRef} className={`app-left-panel${leftVisible ? '' : ' panel-collapsed'}`}>
           {can('panel:navigator') && <Navigator />}
@@ -370,6 +388,8 @@ export function AppLayout() {
               {rightPanelTab === 'marketplace' && <MarketplacePanel />}
               {rightPanelTab === 'wind' && <WindAnalysisPanel />}
               {rightPanelTab === 'admin' && <AdminPanel can={can} />}
+              {rightPanelTab === 'history' && <VersionHistoryPanel />}
+              {rightPanelTab === 'review' && <ReviewPanel />}
             </PanelErrorBoundary>
           </div>
         </aside>

--- a/packages/app/src/components/ReviewPanel.test.tsx
+++ b/packages/app/src/components/ReviewPanel.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * T-REVIEW-001: Design review workflow
+ */
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+expect.extend(jestDomMatchers);
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReviewPanel } from './ReviewPanel';
+
+const mockSetReviewStatus = vi.fn();
+let mockReviewStatus = 'none';
+
+vi.mock('../stores/documentStore', () => ({
+  useDocumentStore: vi.fn(() => ({
+    reviewStatus: mockReviewStatus,
+    setReviewStatus: mockSetReviewStatus,
+  })),
+}));
+
+describe('T-REVIEW-001: ReviewPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReviewStatus = 'none';
+  });
+
+  it('renders Request Review button when status is none', () => {
+    render(<ReviewPanel />);
+    expect(screen.getByRole('button', { name: /Request Review/i })).toBeInTheDocument();
+  });
+
+  it('calls setReviewStatus("pending") when Request Review is clicked', () => {
+    render(<ReviewPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /Request Review/i }));
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('pending');
+  });
+
+  it('shows reviewer list and Approve/Request Changes buttons when status is pending', () => {
+    mockReviewStatus = 'pending';
+    render(<ReviewPanel />);
+    expect(screen.getByRole('button', { name: /Approve/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Request Changes/i })).toBeInTheDocument();
+  });
+
+  it('shows pending indicator when status is pending', () => {
+    mockReviewStatus = 'pending';
+    render(<ReviewPanel />);
+    expect(screen.getByText(/pending/i)).toBeInTheDocument();
+  });
+
+  it('calls setReviewStatus("approved") when Approve is clicked', () => {
+    mockReviewStatus = 'pending';
+    render(<ReviewPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /Approve/i }));
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('approved');
+  });
+
+  it('calls setReviewStatus("changes_requested") when Request Changes is clicked', () => {
+    mockReviewStatus = 'pending';
+    render(<ReviewPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /Request Changes/i }));
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('changes_requested');
+  });
+
+  it('shows green approved badge when status is approved', () => {
+    mockReviewStatus = 'approved';
+    render(<ReviewPanel />);
+    const badge = screen.getByTestId('review-approved-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent(/approved/i);
+  });
+
+  it('shows comment textarea when status is changes_requested', () => {
+    mockReviewStatus = 'changes_requested';
+    render(<ReviewPanel />);
+    expect(screen.getByRole('textbox', { name: /comment/i })).toBeInTheDocument();
+  });
+
+  it('shows changes requested indicator when status is changes_requested', () => {
+    mockReviewStatus = 'changes_requested';
+    render(<ReviewPanel />);
+    expect(screen.getByText(/changes requested/i)).toBeInTheDocument();
+  });
+
+  it('allows returning to none status from approved state', () => {
+    mockReviewStatus = 'approved';
+    render(<ReviewPanel />);
+    const resetBtn = screen.getByRole('button', { name: /New Review/i });
+    fireEvent.click(resetBtn);
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('none');
+  });
+});

--- a/packages/app/src/components/ReviewPanel.tsx
+++ b/packages/app/src/components/ReviewPanel.tsx
@@ -1,0 +1,120 @@
+/**
+ * ReviewPanel — design review workflow panel.
+ * T-REVIEW-001: Request Review → Approve / Request Changes flow.
+ */
+
+import React from 'react';
+import { CheckCircle, GitPullRequest, XCircle } from 'lucide-react';
+import { useDocumentStore } from '../stores/documentStore';
+
+type ReviewStatus = 'none' | 'pending' | 'approved' | 'changes_requested';
+
+export function ReviewPanel(): React.ReactElement {
+  const { reviewStatus, setReviewStatus } = useDocumentStore() as {
+    reviewStatus: ReviewStatus;
+    setReviewStatus: (status: ReviewStatus) => void;
+  };
+
+  return (
+    <div className="review-panel">
+      <div className="panel-header">
+        <span className="panel-title">Design Review</span>
+      </div>
+
+      <div className="review-body">
+        {reviewStatus === 'none' && (
+          <div className="review-section">
+            <p className="review-hint">Submit this design for team review before finalizing.</p>
+            <button
+              className="btn-review btn-request-review"
+              onClick={() => setReviewStatus('pending')}
+            >
+              <GitPullRequest size={14} />
+              Request Review
+            </button>
+          </div>
+        )}
+
+        {reviewStatus === 'pending' && (
+          <div className="review-section">
+            <div className="review-status-indicator">
+              <span className="review-status-dot review-status-dot--pending" />
+              <span>Review Pending</span>
+            </div>
+            <p className="review-hint">Waiting for reviewers to approve or request changes.</p>
+            <div className="review-reviewer-list">
+              <p className="review-reviewers-label">Reviewers</p>
+              <ul>
+                <li>Reviewer 1</li>
+                <li>Reviewer 2</li>
+              </ul>
+            </div>
+            <div className="review-actions">
+              <button
+                className="btn-review btn-approve"
+                onClick={() => setReviewStatus('approved')}
+              >
+                <CheckCircle size={14} />
+                Approve
+              </button>
+              <button
+                className="btn-review btn-request-changes"
+                onClick={() => setReviewStatus('changes_requested')}
+              >
+                <XCircle size={14} />
+                Request Changes
+              </button>
+            </div>
+          </div>
+        )}
+
+        {reviewStatus === 'approved' && (
+          <div className="review-section">
+            <span
+              data-testid="review-approved-badge"
+              className="review-approved-badge"
+              style={{ color: '#22c55e', fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}
+            >
+              <CheckCircle size={16} />
+              Approved
+            </span>
+            <p className="review-hint" style={{ marginTop: 8 }}>This design has been approved by reviewers.</p>
+            <button
+              className="btn-review btn-new-review"
+              onClick={() => setReviewStatus('none')}
+            >
+              New Review
+            </button>
+          </div>
+        )}
+
+        {reviewStatus === 'changes_requested' && (
+          <div className="review-section">
+            <div className="review-status-indicator">
+              <span className="review-status-dot review-status-dot--changes" />
+              <span>Changes Requested</span>
+            </div>
+            <p className="review-hint">Reviewers have requested changes before approving.</p>
+            <label htmlFor="review-comment" className="review-comment-label">
+              Comment
+            </label>
+            <textarea
+              id="review-comment"
+              aria-label="comment"
+              className="review-comment-textarea"
+              placeholder="Describe the changes needed…"
+              rows={4}
+            />
+            <button
+              className="btn-review btn-request-review"
+              style={{ marginTop: 8 }}
+              onClick={() => setReviewStatus('none')}
+            >
+              Reset Review
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/UpdateBanner.test.tsx
+++ b/packages/app/src/components/UpdateBanner.test.tsx
@@ -1,66 +1,76 @@
 /**
  * UpdateBanner component tests
- * T-DSK-012: Auto-update pipeline
+ * T-DSK-012: Desktop auto-update pipeline
  */
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 expect.extend(jestDomMatchers);
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { UpdateBanner } from './UpdateBanner';
-import type { UpdateInfo } from '../lib/updateCheck';
+import type { TauriUpdateInfo } from '../hooks/useTauri';
+
+vi.mock('../hooks/useTauri', () => ({
+  installUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+const baseInfo: TauriUpdateInfo = {
+  version: '2.0.0',
+  body: 'Major release with new features',
+  date: '2026-04-18',
+};
 
 describe('T-DSK-012: UpdateBanner', () => {
   beforeEach(() => {
     sessionStorage.clear();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
-  it('banner not shown when no update available', () => {
-    const updateInfo: UpdateInfo = { available: false };
-    render(<UpdateBanner updateInfo={updateInfo} />);
-    expect(screen.queryByTestId('update-banner')).toBeNull();
-  });
-
-  it('banner shown with version when update available', () => {
-    const updateInfo: UpdateInfo = {
-      available: true,
-      version: '2.0.0',
-      notes: 'Major release with new features',
-      downloadUrl: 'https://example.com/download/2.0.0',
-    };
-    render(<UpdateBanner updateInfo={updateInfo} />);
-
+  it('renders banner when update info is provided', () => {
+    render(<UpdateBanner info={baseInfo} />);
     expect(screen.getByTestId('update-banner')).toBeTruthy();
+  });
+
+  it('shows the version number', () => {
+    render(<UpdateBanner info={baseInfo} />);
     expect(screen.getByTestId('update-version').textContent).toContain('2.0.0');
   });
 
-  it('download button has correct href', () => {
-    const downloadUrl = 'https://example.com/download/2.0.0';
-    const updateInfo: UpdateInfo = {
-      available: true,
-      version: '2.0.0',
-      notes: 'Release notes',
-      downloadUrl,
-    };
-    render(<UpdateBanner updateInfo={updateInfo} />);
+  it('shows release notes body', () => {
+    render(<UpdateBanner info={baseInfo} />);
+    expect(screen.getByText('Major release with new features')).toBeTruthy();
+  });
 
-    const btn = screen.getByTestId('download-update-btn');
-    expect(btn.getAttribute('href')).toBe(downloadUrl);
+  it('install button is present', () => {
+    render(<UpdateBanner info={baseInfo} />);
+    expect(screen.getByTestId('install-update-btn')).toBeTruthy();
   });
 
   it('dismiss hides the banner', () => {
-    const updateInfo: UpdateInfo = {
-      available: true,
-      version: '2.0.0',
-      notes: 'Release notes',
-      downloadUrl: 'https://example.com/download',
-    };
-    render(<UpdateBanner updateInfo={updateInfo} />);
-
+    render(<UpdateBanner info={baseInfo} />);
     expect(screen.getByTestId('update-banner')).toBeTruthy();
-
     fireEvent.click(screen.getByTestId('dismiss-update-btn'));
+    expect(screen.queryByTestId('update-banner')).toBeNull();
+  });
 
+  it('dismiss calls onDismiss callback', () => {
+    const onDismiss = vi.fn();
+    render(<UpdateBanner info={baseInfo} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId('dismiss-update-btn'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('install button calls installUpdate', async () => {
+    const { installUpdate } = await import('../hooks/useTauri');
+    render(<UpdateBanner info={baseInfo} />);
+    fireEvent.click(screen.getByTestId('install-update-btn'));
+    // Allow the async call to settle
+    await new Promise((r) => setTimeout(r, 0));
+    expect(installUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('banner stays hidden when already dismissed in sessionStorage', () => {
+    sessionStorage.setItem('opencad_update_dismissed', 'true');
+    render(<UpdateBanner info={baseInfo} />);
     expect(screen.queryByTestId('update-banner')).toBeNull();
   });
 });

--- a/packages/app/src/components/UpdateBanner.tsx
+++ b/packages/app/src/components/UpdateBanner.tsx
@@ -4,50 +4,86 @@
  */
 
 import React, { useState } from 'react';
-import type { UpdateInfo } from '../lib/updateCheck';
+import { installUpdate } from '../hooks/useTauri';
+import type { TauriUpdateInfo } from '../hooks/useTauri';
 
 interface UpdateBannerProps {
-  updateInfo: UpdateInfo;
+  /** Update info from the Tauri updater plugin. */
+  info: TauriUpdateInfo;
+  /** Called when the user dismisses the banner. */
+  onDismiss?: () => void;
 }
 
 const SESSION_KEY = 'opencad_update_dismissed';
 
-export function UpdateBanner({ updateInfo }: UpdateBannerProps): React.ReactElement | null {
+export function UpdateBanner({ info, onDismiss }: UpdateBannerProps): React.ReactElement | null {
   const alreadyDismissed = sessionStorage.getItem(SESSION_KEY) === 'true';
   const [dismissed, setDismissed] = useState(alreadyDismissed);
+  const [installing, setInstalling] = useState(false);
 
-  if (!updateInfo.available || dismissed) {
+  if (dismissed) {
     return null;
   }
 
   function handleDismiss(): void {
     sessionStorage.setItem(SESSION_KEY, 'true');
     setDismissed(true);
+    onDismiss?.();
+  }
+
+  async function handleInstall(): Promise<void> {
+    setInstalling(true);
+    await installUpdate();
+    // installUpdate triggers app restart on success; if we reach here there was an error
+    setInstalling(false);
   }
 
   return (
-    <div data-testid="update-banner" role="banner" style={{ padding: '8px 16px', background: '#1e3a5f', color: '#fff', display: 'flex', alignItems: 'center', gap: '12px' }}>
+    <div
+      data-testid="update-banner"
+      role="banner"
+      style={{
+        padding: '8px 16px',
+        background: '#1e3a5f',
+        color: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+      }}
+    >
       <span data-testid="update-version">
-        Version {updateInfo.version} is available
+        Version {info.version} is available
       </span>
-      {updateInfo.notes && (
-        <span style={{ opacity: 0.8, fontSize: '0.875em' }}>{updateInfo.notes}</span>
+      {info.body && (
+        <span style={{ opacity: 0.8, fontSize: '0.875em' }}>{info.body}</span>
       )}
-      {updateInfo.downloadUrl && (
-        <a
-          data-testid="download-update-btn"
-          href={updateInfo.downloadUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: '#7dd3fc', fontWeight: 600 }}
-        >
-          Download update
-        </a>
-      )}
+      <button
+        data-testid="install-update-btn"
+        onClick={() => void handleInstall()}
+        disabled={installing}
+        style={{
+          padding: '4px 10px',
+          background: '#0d99ff',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: installing ? 'not-allowed' : 'pointer',
+          fontWeight: 600,
+          fontSize: '0.875em',
+        }}
+      >
+        {installing ? 'Installing...' : 'Install Update'}
+      </button>
       <button
         data-testid="dismiss-update-btn"
         onClick={handleDismiss}
-        style={{ marginLeft: 'auto', background: 'transparent', border: 'none', color: '#fff', cursor: 'pointer' }}
+        style={{
+          marginLeft: 'auto',
+          background: 'transparent',
+          border: 'none',
+          color: '#fff',
+          cursor: 'pointer',
+        }}
         aria-label="Dismiss update notification"
       >
         Dismiss

--- a/packages/app/src/components/VersionHistoryPanel.test.tsx
+++ b/packages/app/src/components/VersionHistoryPanel.test.tsx
@@ -1,22 +1,26 @@
 /**
  * VersionHistoryPanel component tests
  * T-UI-013: Version history panel creates and restores versions
+ * T-HIST-001: Change tracking history
  */
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 expect.extend(jestDomMatchers);
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { VersionHistoryPanel } from './VersionHistoryPanel';
+import type { ChangeRecord } from '../stores/documentStore';
 
 const mockCreateVersion = vi.fn();
 const mockRestoreVersion = vi.fn();
 const mockGetVersionList = vi.fn();
+let mockChangeHistory: ChangeRecord[] = [];
 
 vi.mock('../stores/documentStore', () => ({
   useDocumentStore: vi.fn(() => ({
     createVersion: mockCreateVersion,
     restoreVersion: mockRestoreVersion,
     getVersionList: mockGetVersionList,
+    changeHistory: mockChangeHistory,
   })),
 }));
 
@@ -24,6 +28,7 @@ describe('T-UI-013: VersionHistoryPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetVersionList.mockReturnValue([]);
+    mockChangeHistory = [];
   });
 
   it('renders Version History title', () => {
@@ -128,5 +133,102 @@ describe('T-UI-013: VersionHistoryPanel', () => {
       expect(versionNumbers[0].textContent).toBe('v3');
       expect(versionNumbers[versionNumbers.length - 1].textContent).toBe('v1');
     });
+  });
+});
+
+// ─── T-HIST-001: Change history ───────────────────────────────────────────────
+
+describe('T-HIST-001: VersionHistoryPanel — change tracking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVersionList.mockReturnValue([]);
+    mockChangeHistory = [];
+  });
+
+  it('renders a Change History section', () => {
+    render(<VersionHistoryPanel />);
+    expect(screen.getByText(/Change History/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no change records', () => {
+    render(<VersionHistoryPanel />);
+    expect(screen.getByText(/No changes recorded yet/i)).toBeInTheDocument();
+  });
+
+  it('renders add change record with element type and id', () => {
+    mockChangeHistory = [
+      {
+        id: 'cr-1',
+        timestamp: new Date('2024-01-15T12:30:00').getTime(),
+        type: 'add',
+        elementId: 'wall-001',
+        elementType: 'wall',
+        userId: 'kenroy',
+      },
+    ];
+    render(<VersionHistoryPanel />);
+    expect(screen.getByText(/added/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/wall/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/wall-001/i)).toBeInTheDocument();
+  });
+
+  it('renders update change record', () => {
+    mockChangeHistory = [
+      {
+        id: 'cr-2',
+        timestamp: Date.now(),
+        type: 'update',
+        elementId: 'door-002',
+        elementType: 'door',
+        userId: 'kenroy',
+      },
+    ];
+    render(<VersionHistoryPanel />);
+    expect(screen.getByText(/updated/i)).toBeInTheDocument();
+  });
+
+  it('renders delete change record', () => {
+    mockChangeHistory = [
+      {
+        id: 'cr-3',
+        timestamp: Date.now(),
+        type: 'delete',
+        elementId: 'slab-003',
+        elementType: 'slab',
+        userId: 'kenroy',
+      },
+    ];
+    render(<VersionHistoryPanel />);
+    expect(screen.getByText(/deleted/i)).toBeInTheDocument();
+  });
+
+  it('shows last 50 changes', () => {
+    mockChangeHistory = Array.from({ length: 60 }, (_, i) => ({
+      id: `cr-${i}`,
+      timestamp: 1700000000000 + i * 1000,
+      type: 'add' as const,
+      elementId: `wall-${i}`,
+      elementType: 'wall',
+      userId: 'kenroy',
+    }));
+    render(<VersionHistoryPanel />);
+    // Should show 50 entries (last 50 of 60)
+    const items = screen.getAllByText(/wall-\d+/);
+    expect(items.length).toBe(50);
+  });
+
+  it('shows the userId for each change', () => {
+    mockChangeHistory = [
+      {
+        id: 'cr-1',
+        timestamp: Date.now(),
+        type: 'add',
+        elementId: 'wall-001',
+        elementType: 'wall',
+        userId: 'Kenroy',
+      },
+    ];
+    render(<VersionHistoryPanel />);
+    expect(screen.getByText(/Kenroy/i)).toBeInTheDocument();
   });
 });

--- a/packages/app/src/components/VersionHistoryPanel.tsx
+++ b/packages/app/src/components/VersionHistoryPanel.tsx
@@ -1,13 +1,22 @@
+/**
+ * VersionHistoryPanel — shows saved version snapshots and change tracking history.
+ * T-UI-013: Version snapshots
+ * T-HIST-001: Change tracking
+ */
 import React, { useState } from 'react';
 import { Tag, RotateCcw } from 'lucide-react';
 import { useDocumentStore } from '../stores/documentStore';
+import type { ChangeRecord } from '../stores/documentStore';
+
+const CHANGE_DISPLAY_LIMIT = 50;
 
 export function VersionHistoryPanel() {
-  const { createVersion, restoreVersion, getVersionList } = useDocumentStore();
+  const { createVersion, restoreVersion, getVersionList, changeHistory } = useDocumentStore();
   const [message, setMessage] = useState('');
   const [restoring, setRestoring] = useState<number | null>(null);
 
   const versions = getVersionList();
+  const recentChanges = (changeHistory ?? []).slice(-CHANGE_DISPLAY_LIMIT);
 
   const handleCreateVersion = () => {
     createVersion(message.trim() || undefined);
@@ -19,6 +28,12 @@ export function VersionHistoryPanel() {
     restoreVersion(versionNumber);
     setRestoring(null);
   };
+
+  function verbFor(record: ChangeRecord): string {
+    if (record.type === 'add') return 'added';
+    if (record.type === 'update') return 'updated';
+    return 'deleted';
+  }
 
   return (
     <div className="version-history-panel">
@@ -69,6 +84,45 @@ export function VersionHistoryPanel() {
               </button>
             </li>
           ))}
+        </ul>
+      )}
+
+      {/* T-HIST-001: Change tracking history */}
+      <div className="panel-header" style={{ marginTop: '16px' }}>
+        <span className="panel-title">Change History</span>
+      </div>
+
+      {recentChanges.length === 0 ? (
+        <p className="version-empty">No changes recorded yet.</p>
+      ) : (
+        <ul
+          className="change-history-list"
+          style={{ listStyle: 'none', padding: 0, margin: 0, overflowY: 'auto', maxHeight: '300px' }}
+        >
+          {recentChanges.map((record) => {
+            const time = new Date(record.timestamp).toLocaleTimeString(undefined, {
+              hour: '2-digit',
+              minute: '2-digit',
+            });
+            return (
+              <li
+                key={record.id}
+                className="change-record-item"
+                data-testid={`change-record-${record.id}`}
+                style={{
+                  fontSize: '0.8em',
+                  padding: '3px 0',
+                  borderBottom: '1px solid var(--border-color, #333)',
+                }}
+              >
+                <span className="change-time" style={{ opacity: 0.6 }}>[{time}]</span>{' '}
+                <span className="change-user">{record.userId}</span>{' '}
+                <span className={`change-verb change-verb-${record.type}`}>{verbFor(record)}</span>{' '}
+                <span className="change-element-type">{record.elementType}</span>{' '}
+                <span className="change-element-id" style={{ opacity: 0.7 }}>({record.elementId})</span>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -10,3 +10,5 @@ export { AIChatPanel } from './AIChatPanel';
 export { ImportExportModal } from './ImportExportModal';
 export { TemplateSelector } from './TemplateSelector';
 export { VersionHistoryPanel } from './VersionHistoryPanel';
+export { ReviewPanel } from './ReviewPanel';
+export { UpdateBanner } from './UpdateBanner';

--- a/packages/app/src/hooks/useTauri.ts
+++ b/packages/app/src/hooks/useTauri.ts
@@ -6,6 +6,7 @@
  * T-DSK-002: openFile(path) — read a native file and return parsed DocumentSchema
  * T-DSK-005: onFileDrop(handler) — register OS drag-and-drop handler
  * T-DSK-006: saveFile(path, content), saveFileDialog, openFileDialog — native FS writes
+ * T-DSK-012: checkForUpdates() — call Tauri updater plugin
  */
 
 import type { DocumentSchema } from '@opencad/document';
@@ -161,17 +162,51 @@ export async function tauriOpenNewWindow(route: string, title: string): Promise<
   return invoke('open_new_window', { route, title });
 }
 
-// ─── Updates ─────────────────────────────────────────────────
+// ─── T-DSK-012: Updates via Tauri updater plugin ─────────────────────────────
 
+/** Shape returned by the Tauri updater plugin (plugin:updater|check). */
 export interface TauriUpdateInfo {
+  version: string;
+  body: string;
+  date: string;
+}
+
+/**
+ * T-DSK-012: Check for updates via the Tauri updater plugin.
+ * Returns null when not in Tauri or when the updater plugin throws.
+ */
+export async function checkForUpdates(): Promise<TauriUpdateInfo | null> {
+  if (!isTauri()) return null;
+  try {
+    return await window.__TAURI__!.core.invoke<TauriUpdateInfo>('plugin:updater|check');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * T-DSK-012: Install the pending update via the Tauri updater plugin.
+ * No-op outside of Tauri.
+ */
+export async function installUpdate(): Promise<void> {
+  if (!isTauri()) return;
+  try {
+    await window.__TAURI__!.core.invoke<void>('plugin:updater|install');
+  } catch {
+    // Ignore — app will restart on success
+  }
+}
+
+/** Legacy update status from the custom check_for_update Tauri command. */
+interface TauriUpdateStatus {
   available: boolean;
   version: string | null;
   notes: string | null;
   url: string | null;
 }
 
-export async function tauriCheckForUpdate(): Promise<TauriUpdateInfo> {
-  return invoke<TauriUpdateInfo>('check_for_update');
+export async function tauriCheckForUpdate(): Promise<TauriUpdateStatus> {
+  return invoke<TauriUpdateStatus>('check_for_update');
 }
 
 // ─── React hook ──────────────────────────────────────────────
@@ -181,7 +216,7 @@ import { useState, useEffect } from 'react';
 export interface TauriState {
   isDesktop: boolean;
   localAI: TauriLocalAIStatus | null;
-  updateInfo: TauriUpdateInfo | null;
+  updateInfo: TauriUpdateStatus | null;
   storageUsed: number;
   storageTotal: number;
 }
@@ -189,7 +224,7 @@ export interface TauriState {
 export function useTauri(): TauriState {
   const isDesktop = isTauri();
   const [localAI, setLocalAI] = useState<TauriLocalAIStatus | null>(null);
-  const [updateInfo, setUpdateInfo] = useState<TauriUpdateInfo | null>(null);
+  const [updateInfo, setUpdateInfo] = useState<TauriUpdateStatus | null>(null);
   const [storageUsed, setStorageUsed] = useState(0);
   const [storageTotal, setStorageTotal] = useState(0);
 

--- a/packages/app/src/hooks/useTauri.update.test.ts
+++ b/packages/app/src/hooks/useTauri.update.test.ts
@@ -1,0 +1,65 @@
+/**
+ * T-DSK-012: Auto-update via Tauri updater plugin
+ * Tests for checkForUpdates() function in useTauri.ts
+ */
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+expect.extend(jestDomMatchers);
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('T-DSK-012: checkForUpdates()', () => {
+  const mockInvoke = vi.fn();
+
+  beforeEach(() => {
+    (window as Window & { __TAURI__?: { core: { invoke: typeof mockInvoke } } }).__TAURI__ = {
+      core: { invoke: mockInvoke },
+    };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete (window as Window & { __TAURI__?: unknown }).__TAURI__;
+  });
+
+  it('exports checkForUpdates as a function', async () => {
+    const { checkForUpdates } = await import('./useTauri');
+    expect(typeof checkForUpdates).toBe('function');
+  });
+
+  it('calls plugin:updater|check via invoke', async () => {
+    const updateInfo = { version: '2.0.0', body: 'Bug fixes', date: '2024-01-15' };
+    mockInvoke.mockResolvedValue(updateInfo);
+    const { checkForUpdates } = await import('./useTauri');
+    const result = await checkForUpdates();
+    expect(mockInvoke).toHaveBeenCalledWith('plugin:updater|check');
+    expect(result).toEqual(updateInfo);
+  });
+
+  it('returns null when not in Tauri environment', async () => {
+    delete (window as Window & { __TAURI__?: unknown }).__TAURI__;
+    const { checkForUpdates } = await import('./useTauri');
+    const result = await checkForUpdates();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when updater plugin throws', async () => {
+    mockInvoke.mockRejectedValue(new Error('updater plugin not available'));
+    const { checkForUpdates } = await import('./useTauri');
+    const result = await checkForUpdates();
+    expect(result).toBeNull();
+  });
+
+  it('returns update info with correct shape when update is available', async () => {
+    const updateInfo = {
+      version: '1.5.2',
+      body: 'New features and fixes',
+      date: '2024-03-20T12:00:00Z',
+    };
+    mockInvoke.mockResolvedValue(updateInfo);
+    const { checkForUpdates } = await import('./useTauri');
+    const result = await checkForUpdates();
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe('1.5.2');
+    expect(result!.body).toBe('New features and fixes');
+    expect(result!.date).toBe('2024-03-20T12:00:00Z');
+  });
+});

--- a/packages/app/src/stores/documentStore.ts
+++ b/packages/app/src/stores/documentStore.ts
@@ -25,6 +25,18 @@ interface HistoryEntry {
   description: string;
 }
 
+/** T-HIST-001: A record of a single document change for the history panel. */
+export interface ChangeRecord {
+  id: string;
+  timestamp: number;
+  type: 'add' | 'update' | 'delete';
+  elementId: string;
+  elementType: string;
+  userId: string;
+}
+
+const MAX_CHANGE_HISTORY = 200;
+
 interface DocumentState {
   document: DocumentSchema | null;
   model: DocumentModel | null;
@@ -44,6 +56,13 @@ interface DocumentState {
   userRole: RoleId | null;
 
   toolParams: Record<string, Record<string, unknown>>;
+
+  /** T-HIST-001: Ordered list of recent change records (capped at MAX_CHANGE_HISTORY). */
+  changeHistory: ChangeRecord[];
+
+  /** T-REVIEW-001: Current design review status. */
+  reviewStatus: 'none' | 'pending' | 'approved' | 'changes_requested';
+  setReviewStatus: (status: 'none' | 'pending' | 'approved' | 'changes_requested') => void;
 
   initProject: (projectId: string, userId: string) => void;
   loadProject: (projectId: string, userId: string) => void;
@@ -115,6 +134,11 @@ export const useDocumentStore = create<DocumentState>()(
         door: { height: 2100, width: 900, swing: 90 },
         window: { height: 1200, width: 1200, sillHeight: 900 },
       },
+
+      changeHistory: [],
+
+      reviewStatus: 'none',
+      setReviewStatus: (status) => set({ reviewStatus: status }),
 
       initProject: (projectId, userId) => {
         let model: DocumentModel;
@@ -251,7 +275,7 @@ export const useDocumentStore = create<DocumentState>()(
       },
 
       addElement: (params) => {
-        const { model } = get();
+        const { model, changeHistory } = get();
         if (!model) throw new Error('No document loaded');
 
         const props = (params.properties || {}) as Record<string, PropertyValue>;
@@ -269,9 +293,18 @@ export const useDocumentStore = create<DocumentState>()(
 
         const newDoc = { ...model.documentData };
         const newDocJson = JSON.stringify(newDoc);
+        const addRecord: ChangeRecord = {
+          id: crypto.randomUUID(),
+          timestamp: Date.now(),
+          type: 'add',
+          elementId,
+          elementType: params.type,
+          userId: model.client,
+        };
         set({
           document: newDoc,
           lastSaved: Date.now(),
+          changeHistory: [...changeHistory, addRecord].slice(-MAX_CHANGE_HISTORY),
         });
         try {
           localStorage.setItem('opencad-document', newDocJson);
@@ -282,24 +315,45 @@ export const useDocumentStore = create<DocumentState>()(
       },
 
       updateElement: (elementId, updates) => {
-        const { model } = get();
+        const { model, changeHistory } = get();
         if (!model) return;
 
         const element = model.getElementById(elementId);
         if (element) {
+          const updateRecord: ChangeRecord = {
+            id: crypto.randomUUID(),
+            timestamp: Date.now(),
+            type: 'update',
+            elementId,
+            elementType: element.type ?? 'unknown',
+            userId: model.client,
+          };
           Object.assign(element, updates);
-          set({ document: { ...model.documentData } });
+          set({
+            document: { ...model.documentData },
+            changeHistory: [...changeHistory, updateRecord].slice(-MAX_CHANGE_HISTORY),
+          });
         }
       },
 
       deleteElement: (elementId) => {
-        const { model, document } = get();
+        const { model, document, changeHistory } = get();
         if (!model || !document) return;
 
+        const deletedEl = document.content.elements[elementId];
+        const deleteRecord: ChangeRecord = {
+          id: crypto.randomUUID(),
+          timestamp: Date.now(),
+          type: 'delete',
+          elementId,
+          elementType: deletedEl?.type ?? 'unknown',
+          userId: model.client,
+        };
         delete document.content.elements[elementId];
         set({
           document: { ...document },
           lastSaved: Date.now(),
+          changeHistory: [...changeHistory, deleteRecord].slice(-MAX_CHANGE_HISTORY),
         });
       },
 


### PR DESCRIPTION
## Summary

- **T-DSK-012 (Desktop auto-update)**: Added `checkForUpdates()` and `installUpdate()` to `useTauri.ts` using the Tauri updater plugin protocol (`plugin:updater|check` / `plugin:updater|install`). `AppLayout` now calls `checkForUpdates()` on mount (Tauri only) and renders an `UpdateBanner` with install + dismiss actions when an update is available.
- **T-HIST-001 (Change tracking history)**: Added `ChangeRecord` interface and `changeHistory: ChangeRecord[]` state to `documentStore`. Every `addElement`, `updateElement`, and `deleteElement` call appends a record (capped at 200). `VersionHistoryPanel` now shows a "Change History" section displaying the last 50 records in `[time] userId verb elementType (elementId)` format.
- **T-REVIEW-001 (Design review workflow)**: New `ReviewPanel` component implementing a none → pending → approved/changes_requested state machine. `reviewStatus` and `setReviewStatus` added to the document store. History and Review are wired as new tabs in the AppLayout right panel.

## Test plan

- [ ] `useTauri.update.test.ts` — 4 tests covering null-in-browser, plugin invocation, error fallback, correct return shape
- [ ] `UpdateBanner.test.tsx` — 8 tests covering render, version display, install button, dismiss, sessionStorage persistence, onDismiss callback
- [ ] `VersionHistoryPanel.test.tsx` — T-UI-013 tests preserved + T-HIST-001 tests for change records (add/update/delete verbs, empty state, last-50 limit, userId display)
- [ ] `ReviewPanel.test.tsx` — 10 T-REVIEW-001 tests covering all four states and button interactions
- All 138 test files / 1829 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)