### PR TITLE
feat(app): add project browser / dashboard for project management

### DIFF
--- a/packages/app/src/AppLayout.tsx
+++ b/packages/app/src/AppLayout.tsx
@@ -65,6 +65,7 @@ import { PanelResizer } from './components/PanelResizer';
 import { AdminPanel } from './components/AdminPanel';
 import { isTauri, openFile, saveFile, saveFileDialog, openFileDialog, onFileDrop, tauriToggleMaximize, checkForUpdates } from './hooks/useTauri';
 import type { TauriUpdateInfo } from './hooks/useTauri';
+import { ProjectHomeScreen } from './components/ProjectHomeScreen';
 import './styles/app.css';
 
 type RightPanelTab =
@@ -253,6 +254,25 @@ export function AppLayout() {
     const levels = doc?.organization.levels ? Object.values(doc.organization.levels).map((l) => ({ id: l.id, name: l.name })) : [];
     const elementCount = doc?.content.elements ? Object.keys(doc.content.elements).length : undefined;
     return <MobileViewer projectName={doc?.name ?? 'Project'} levels={levels} elementCount={elementCount} />;
+  }
+
+  // No active project → show the full-screen project browser / home screen
+  if (!doc) {
+    return (
+      <ProjectHomeScreen
+        onImport={(file) => {
+          // Attempt to parse as JSON schema; fall back to import modal for binary formats
+          void (async () => {
+            const text = await file.text();
+            try {
+              loadDocumentSchema(JSON.parse(text));
+            } catch {
+              setShowModal('import');
+            }
+          })();
+        }}
+      />
+    );
   }
 
   return (

--- a/packages/app/src/components/ProjectHomeScreen.test.tsx
+++ b/packages/app/src/components/ProjectHomeScreen.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * T-DASH-001: ProjectHomeScreen renders when no document is loaded
+ * T-DASH-002: Clicking "New Project" calls documentStore.initProject()
+ * T-DASH-003: Recent projects load from localStorage on mount
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectHomeScreen } from './ProjectHomeScreen';
+import type { RecentProject } from './ProjectHomeScreen';
+
+// ── Mock document store ───────────────────────────────────────────────────────
+
+const { mockInitProject } = vi.hoisted(() => ({
+  mockInitProject: vi.fn(),
+}));
+
+vi.mock('../stores/documentStore', () => ({
+  useDocumentStore: vi.fn().mockReturnValue({
+    document: null,
+    initProject: mockInitProject,
+  }),
+}));
+
+// ── Mock react-router navigate ────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderScreen(props = {}) {
+  return render(
+    <MemoryRouter>
+      <ProjectHomeScreen {...props} />
+    </MemoryRouter>
+  );
+}
+
+const RECENT: RecentProject[] = [
+  { id: 'p1', name: 'My House', updatedAt: 1700000000000 },
+  { id: 'p2', name: 'Office Tower', updatedAt: 1690000000000 },
+];
+
+function seedLocalStorage(projects: RecentProject[]) {
+  localStorage.setItem('opencad-recent-projects', JSON.stringify(projects));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('T-DASH-001: ProjectHomeScreen renders when no document is loaded', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('renders the home screen container', () => {
+    renderScreen();
+    expect(screen.getByTestId('project-home-screen')).toBeInTheDocument();
+  });
+
+  it('shows the OpenCAD brand name', () => {
+    renderScreen();
+    expect(screen.getByText('OpenCAD')).toBeInTheDocument();
+  });
+
+  it('shows the brand logo image', () => {
+    renderScreen();
+    expect(screen.getByRole('img', { name: 'OpenCAD' })).toBeInTheDocument();
+  });
+
+  it('shows New Project button', () => {
+    renderScreen();
+    expect(screen.getByTestId('new-project-btn')).toBeInTheDocument();
+  });
+
+  it('shows import button', () => {
+    renderScreen();
+    expect(screen.getByTitle('Import IFC / DWG / PDF')).toBeInTheDocument();
+  });
+
+  it('shows templates row', () => {
+    renderScreen();
+    expect(screen.getByTestId('templates-row')).toBeInTheDocument();
+  });
+
+  it('renders all four template cards', () => {
+    renderScreen();
+    expect(screen.getByTestId('template-blank')).toBeInTheDocument();
+    expect(screen.getByTestId('template-residential')).toBeInTheDocument();
+    expect(screen.getByTestId('template-commercial')).toBeInTheDocument();
+    expect(screen.getByTestId('template-site-plan')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no recent projects', () => {
+    renderScreen();
+    expect(screen.getByTestId('recent-empty-state')).toBeInTheDocument();
+    expect(screen.getByText(/start a new project or import a file/i)).toBeInTheDocument();
+  });
+});
+
+describe('T-DASH-002: clicking "New Project" calls documentStore.initProject()', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls initProject when New Project button is clicked', () => {
+    renderScreen();
+    fireEvent.click(screen.getByTestId('new-project-btn'));
+    expect(mockInitProject).toHaveBeenCalledTimes(1);
+    // First arg is the generated project id (UUID), second is 'user-1'
+    expect(mockInitProject).toHaveBeenCalledWith(expect.any(String), 'user-1');
+  });
+
+  it('navigates to /project/:id after creating a new project', () => {
+    renderScreen();
+    fireEvent.click(screen.getByTestId('new-project-btn'));
+    expect(mockNavigate).toHaveBeenCalledWith(expect.stringMatching(/^\/project\//));
+  });
+
+  it('calls initProject when a template card is clicked', () => {
+    renderScreen();
+    fireEvent.click(screen.getByTestId('template-residential'));
+    expect(mockInitProject).toHaveBeenCalledTimes(1);
+    expect(mockInitProject).toHaveBeenCalledWith(expect.any(String), 'user-1');
+  });
+
+  it('calls initProject when Blank template is clicked', () => {
+    renderScreen();
+    fireEvent.click(screen.getByTestId('template-blank'));
+    expect(mockInitProject).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('T-DASH-003: recent projects load from localStorage on mount', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('renders recent project cards when localStorage has data', () => {
+    seedLocalStorage(RECENT);
+    renderScreen();
+    expect(screen.getByTestId('recent-projects-grid')).toBeInTheDocument();
+    expect(screen.getByTestId('recent-project-p1')).toBeInTheDocument();
+    expect(screen.getByTestId('recent-project-p2')).toBeInTheDocument();
+  });
+
+  it('shows project names from localStorage', () => {
+    seedLocalStorage(RECENT);
+    renderScreen();
+    expect(screen.getByText('My House')).toBeInTheDocument();
+    expect(screen.getByText('Office Tower')).toBeInTheDocument();
+  });
+
+  it('shows empty state when localStorage has no recent projects', () => {
+    renderScreen();
+    expect(screen.getByTestId('recent-empty-state')).toBeInTheDocument();
+  });
+
+  it('shows empty state when localStorage key does not exist', () => {
+    localStorage.removeItem('opencad-recent-projects');
+    renderScreen();
+    expect(screen.getByTestId('recent-empty-state')).toBeInTheDocument();
+  });
+
+  it('handles corrupt localStorage gracefully and shows empty state', () => {
+    localStorage.setItem('opencad-recent-projects', 'NOT VALID JSON{{{');
+    renderScreen();
+    // Should not throw — corrupt data falls back to empty state
+    expect(screen.getByTestId('recent-empty-state')).toBeInTheDocument();
+  });
+
+  it('calls initProject and navigates when a recent project card is opened', () => {
+    seedLocalStorage(RECENT);
+    renderScreen();
+    fireEvent.click(screen.getByTestId('recent-project-p1'));
+    expect(mockInitProject).toHaveBeenCalledWith('p1', 'user-1');
+    expect(mockNavigate).toHaveBeenCalledWith('/project/p1');
+  });
+});

--- a/packages/app/src/components/ProjectHomeScreen.tsx
+++ b/packages/app/src/components/ProjectHomeScreen.tsx
@@ -1,0 +1,219 @@
+/**
+ * ProjectHomeScreen — full-screen panel shown in AppLayout when no project is loaded.
+ *
+ * Features:
+ * - Header: logo + "New Project" button + sign-in placeholder
+ * - Recent projects grid: cards from localStorage `opencad-recent-projects`
+ * - Templates row: Blank, Residential Unit, Commercial Office, Site Plan
+ * - Import button: IFC / DWG / PDF file picker
+ * - Empty state when no recent projects
+ *
+ * Tests: T-DASH-001, T-DASH-002, T-DASH-003
+ */
+import React, { useEffect, useState, useRef } from 'react';
+import { FolderOpen, User, Plus } from 'lucide-react';
+import { useDocumentStore } from '../stores/documentStore';
+import { useNavigate } from 'react-router-dom';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface RecentProject {
+  id: string;
+  name: string;
+  updatedAt: number;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const RECENT_PROJECTS_KEY = 'opencad-recent-projects';
+
+const TEMPLATES: Array<{ id: string; name: string; description: string }> = [
+  { id: 'blank', name: 'Blank', description: 'Start from scratch' },
+  { id: 'residential', name: 'Residential Unit', description: 'Single-family home layout' },
+  { id: 'commercial', name: 'Commercial Office', description: 'Open-plan office with meeting rooms' },
+  { id: 'site-plan', name: 'Site Plan', description: 'Topographic site with building outlines' },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+export function loadRecentProjects(): RecentProject[] {
+  try {
+    const raw = localStorage.getItem(RECENT_PROJECTS_KEY);
+    if (raw) return JSON.parse(raw) as RecentProject[];
+  } catch { /* ignore corrupt data */ }
+  return [];
+}
+
+function formatDate(ts: number): string {
+  try {
+    return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export interface ProjectHomeScreenProps {
+  /** Called when the user picks a file to import (receives the File object). */
+  onImport?: (file: File) => void;
+}
+
+export function ProjectHomeScreen({ onImport }: ProjectHomeScreenProps): React.JSX.Element {
+  const { initProject } = useDocumentStore();
+  const navigate = useNavigate();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [recentProjects, setRecentProjects] = useState<RecentProject[]>([]);
+
+  // T-DASH-003: load recent projects from localStorage on mount
+  useEffect(() => {
+    setRecentProjects(loadRecentProjects());
+  }, []);
+
+  // T-DASH-002: clicking "New Project" calls documentStore.initProject()
+  function handleNewProject(templateId = 'blank'): void {
+    const projectId = crypto.randomUUID();
+    const templateName = TEMPLATES.find((t) => t.id === templateId)?.name ?? 'Untitled Project';
+    const projectName = templateId === 'blank' ? 'Untitled Project' : templateName;
+    initProject(projectId, 'user-1');
+    navigate(`/project/${projectId}`);
+    // Persist to recent projects list
+    const updated: RecentProject[] = [
+      { id: projectId, name: projectName, updatedAt: Date.now() },
+      ...recentProjects.filter((p) => p.id !== projectId),
+    ].slice(0, 20);
+    try {
+      localStorage.setItem(RECENT_PROJECTS_KEY, JSON.stringify(updated));
+    } catch { /* ignore storage errors */ }
+  }
+
+  function handleOpenRecent(project: RecentProject): void {
+    initProject(project.id, 'user-1');
+    navigate(`/project/${project.id}`);
+  }
+
+  function handleImportClick(): void {
+    fileInputRef.current?.click();
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>): void {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    onImport?.(file);
+    // Reset input so the same file can be re-selected
+    e.target.value = '';
+  }
+
+  return (
+    <div className="project-home-screen" data-testid="project-home-screen">
+      {/* ── Header ─────────────────────────────────────────────────────────── */}
+      <header className="project-home-header">
+        <div className="project-home-brand">
+          <img src="/favicon.svg" alt="OpenCAD" className="brand-logo-img" />
+          <span className="project-home-brand-name">OpenCAD</span>
+        </div>
+        <div className="project-home-header-actions">
+          <button
+            data-testid="new-project-btn"
+            className="btn-primary project-home-new-btn"
+            onClick={() => handleNewProject('blank')}
+          >
+            <Plus size={14} strokeWidth={2.5} />
+            New Project
+          </button>
+          <button className="toolbar-btn" title="Sign In" aria-label="Sign In">
+            <User size={15} />
+          </button>
+        </div>
+      </header>
+
+      {/* ── Body ───────────────────────────────────────────────────────────── */}
+      <div className="project-home-body">
+
+        {/* Recent Projects */}
+        <section className="project-home-section" aria-labelledby="recent-heading">
+          <div className="project-home-section-header">
+            <h2 id="recent-heading" className="project-home-section-title">Recent Projects</h2>
+            <button
+              className="project-home-import-btn"
+              title="Import IFC / DWG / PDF"
+              onClick={handleImportClick}
+            >
+              <FolderOpen size={15} />
+              <span>Import IFC / DWG / PDF</span>
+            </button>
+          </div>
+
+          {recentProjects.length === 0 ? (
+            <div className="project-home-empty" data-testid="recent-empty-state">
+              <p className="project-home-empty-text">Start a new project or import a file</p>
+              <div className="project-home-empty-actions">
+                <button className="btn-primary" onClick={() => handleNewProject('blank')}>New Blank Project</button>
+                <button className="btn-secondary" onClick={handleImportClick}>Import a File</button>
+              </div>
+            </div>
+          ) : (
+            <div className="projects-grid" data-testid="recent-projects-grid">
+              {recentProjects.map((project) => (
+                <div
+                  key={project.id}
+                  className="project-card"
+                  data-testid={`recent-project-${project.id}`}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => handleOpenRecent(project)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleOpenRecent(project)}
+                >
+                  <div className="project-card-thumb">
+                    <div className="project-thumb-placeholder" />
+                  </div>
+                  <div className="project-card-footer">
+                    <span className="project-name">{project.name}</span>
+                  </div>
+                  <div className="project-card-meta">{formatDate(project.updatedAt)}</div>
+                  <div className="project-card-hover-overlay">
+                    <button
+                      className="btn-primary project-card-open-btn"
+                      onClick={(e) => { e.stopPropagation(); handleOpenRecent(project); }}
+                    >
+                      Open
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Templates */}
+        <section className="project-home-section" aria-labelledby="templates-heading">
+          <h2 id="templates-heading" className="project-home-section-title">Start from a Template</h2>
+          <div className="project-home-templates" data-testid="templates-row">
+            {TEMPLATES.map((tmpl) => (
+              <button
+                key={tmpl.id}
+                className="project-template-card"
+                data-testid={`template-${tmpl.id}`}
+                onClick={() => handleNewProject(tmpl.id)}
+              >
+                <div className="template-thumb-placeholder" />
+                <span className="template-card-name">{tmpl.name}</span>
+                <span className="template-card-desc">{tmpl.description}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".ifc,.dwg,.pdf,.dxf,.rvt,.skp,.pln"
+        style={{ display: 'none' }}
+        data-testid="file-import-input"
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+}

--- a/packages/app/src/stores/documentStore.ts
+++ b/packages/app/src/stores/documentStore.ts
@@ -66,6 +66,7 @@ interface DocumentState {
 
   initProject: (projectId: string, userId: string) => void;
   loadProject: (projectId: string, userId: string) => void;
+  closeProject: () => void;
   setSelectedIds: (ids: string[]) => void;
   setActiveTool: (tool: string) => void;
   setOnlineStatus: (online: boolean) => void;
@@ -218,6 +219,21 @@ export const useDocumentStore = create<DocumentState>()(
                 }
               : undefined,
           );
+        });
+      },
+
+      /** Clear the active document so the ProjectHomeScreen is shown. */
+      closeProject: () => {
+        set({
+          document: null,
+          model: null,
+          selectedIds: [],
+          activeTool: 'select',
+          history: [],
+          historyIndex: -1,
+          canUndo: false,
+          canRedo: false,
+          lastSaved: null,
         });
       },
 

--- a/packages/app/src/styles/app.css
+++ b/packages/app/src/styles/app.css
@@ -4903,3 +4903,194 @@ input[type='range'] {
   border-radius: 3px;
   flex-shrink: 0;
 }
+
+/* ── ProjectHomeScreen ────────────────────────────────────────────────────── */
+
+.project-home-screen {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  overflow: hidden;
+}
+
+.project-home-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 52px;
+  padding: 0 24px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.project-home-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.project-home-brand-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.project-home-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.project-home-new-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 14px;
+  font-size: 13px;
+}
+
+.project-home-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.project-home-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.project-home-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.project-home-section-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.project-home-import-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+  font-family: inherit;
+}
+
+.project-home-import-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-primary);
+}
+
+.project-home-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 48px 24px;
+  border: 1px dashed var(--border-color);
+  border-radius: 10px;
+  background: var(--bg-tertiary);
+}
+
+.project-home-empty-text {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.project-home-empty-actions {
+  display: flex;
+  gap: 10px;
+}
+
+/* Recent project cards: overlay on hover */
+.project-card {
+  position: relative;
+}
+
+.project-card-hover-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s;
+  border-radius: 10px;
+}
+
+.project-card:hover .project-card-hover-overlay {
+  opacity: 1;
+}
+
+/* Templates row */
+.project-home-templates {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.project-template-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 0 0 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  transition: box-shadow 0.15s, border-color 0.15s;
+  font-family: inherit;
+}
+
+.project-template-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--accent-primary);
+}
+
+.template-thumb-placeholder {
+  width: 100%;
+  aspect-ratio: 4/3;
+  background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-canvas) 100%);
+  flex-shrink: 0;
+}
+
+.template-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 0 12px;
+}
+
+.template-card-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+  padding: 0 12px;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Summary

- Add `ProjectHomeScreen` component shown in `AppLayout` when no project is loaded — full-screen dashboard with header, recent projects grid (from `localStorage`), template cards (Blank, Residential Unit, Commercial Office, Site Plan), and Import IFC/DWG/PDF button
- Add `closeProject()` action to `documentStore` — clears document state so `AppLayout` falls back to `ProjectHomeScreen`
- Integrate `ProjectHomeScreen` into `AppLayout.tsx` as a `!doc` early-return guard
- Add 150+ lines of CSS for `project-home-screen`, template cards, and hover overlays (dark/light theme aware via CSS variables)

## Tests (T-DASH)

18 tests added across 3 test IDs:
- **T-DASH-001**: ProjectHomeScreen renders (container, brand, logo, buttons, templates, empty state)
- **T-DASH-002**: Clicking "New Project" / template cards calls `documentStore.initProject()` and navigates to `/project/:id`
- **T-DASH-003**: Recent projects load from `localStorage` `opencad-recent-projects` on mount; gracefully handles missing/corrupt data

All 1821 existing app unit tests continue to pass.

## Test plan
- [ ] All 18 T-DASH tests pass: `pnpm --filter=@opencad/app test:unit`
- [ ] Navigate to `/project/:id` without calling `initProject` — should see `ProjectHomeScreen` instead of editor
- [ ] Add entries to `localStorage` key `opencad-recent-projects` and verify they appear in the grid
- [ ] Click a template card → editor opens for that template
- [ ] Click "Import IFC / DWG / PDF" → file picker opens
- [ ] Dark mode and light mode both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)