### PR TITLE
feat(auth): T-AUTH-007 MFA TOTP enrollment and challenge resolution

### DIFF
--- a/packages/app/src/components/AuthModal.mfa.test.tsx
+++ b/packages/app/src/components/AuthModal.mfa.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * T-AUTH-007: MFA TOTP challenge step in AuthModal
+ *
+ * Tests that the AuthModal detects `auth/multi-factor-auth-required` errors
+ * and transitions to a TOTP OTP input step.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AuthModal } from './AuthModal';
+
+// ─── Auth store mock ─────────────────────────────────────────────────────────
+
+const mockSignIn = vi.fn();
+const mockSignUp = vi.fn();
+const mockResolveMfaChallenge = vi.fn();
+
+vi.mock('../stores/authStore', () => ({
+  useAuthStore: () => ({
+    signIn: mockSignIn,
+    signUp: mockSignUp,
+    resolveMfaChallenge: mockResolveMfaChallenge,
+  }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a fake Firebase MFA-required error */
+function makeMfaError(resolver: unknown) {
+  return Object.assign(new Error('MFA required'), {
+    code: 'auth/multi-factor-auth-required',
+    customData: { _serverResponse: {} },
+    resolver,
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('T-AUTH-007: AuthModal MFA TOTP challenge step', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('T-AUTH-007-08: shows TOTP input step when signIn throws auth/multi-factor-auth-required', async () => {
+    const mockResolver = { hints: [{ factorId: 'totp', uid: 'hint-uid' }] };
+    mockSignIn.mockRejectedValue(makeMfaError(mockResolver));
+
+    render(<AuthModal onClose={onClose} />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'mfa@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/authenticator code/i)).toBeInTheDocument();
+    });
+  });
+
+  it('T-AUTH-007-09: TOTP input step shows descriptive heading', async () => {
+    const mockResolver = { hints: [{ factorId: 'totp', uid: 'hint-uid' }] };
+    mockSignIn.mockRejectedValue(makeMfaError(mockResolver));
+
+    render(<AuthModal onClose={onClose} />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'mfa@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/two-factor authentication/i)).toBeInTheDocument();
+    });
+  });
+
+  it('T-AUTH-007-10: submitting TOTP code calls resolveMfaChallenge with resolver and OTP', async () => {
+    const mockResolver = { hints: [{ factorId: 'totp', uid: 'hint-uid' }] };
+    mockSignIn.mockRejectedValue(makeMfaError(mockResolver));
+    mockResolveMfaChallenge.mockResolvedValue(undefined);
+
+    render(<AuthModal onClose={onClose} />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'mfa@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => screen.getByLabelText(/authenticator code/i));
+
+    fireEvent.change(screen.getByLabelText(/authenticator code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /verify/i }));
+
+    await waitFor(() => {
+      expect(mockResolveMfaChallenge).toHaveBeenCalledWith(mockResolver, '123456');
+    });
+  });
+
+  it('T-AUTH-007-11: shows error when TOTP verification fails', async () => {
+    const mockResolver = { hints: [{ factorId: 'totp', uid: 'hint-uid' }] };
+    mockSignIn.mockRejectedValue(makeMfaError(mockResolver));
+    mockResolveMfaChallenge.mockRejectedValue(
+      Object.assign(new Error('Invalid OTP'), { code: 'auth/invalid-verification-code' }),
+    );
+
+    render(<AuthModal onClose={onClose} />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'mfa@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => screen.getByLabelText(/authenticator code/i));
+
+    fireEvent.change(screen.getByLabelText(/authenticator code/i), {
+      target: { value: '000000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /verify/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('T-AUTH-007-12: non-MFA signIn errors still show inline error (not TOTP step)', async () => {
+    mockSignIn.mockRejectedValue({ code: 'auth/wrong-password' });
+
+    render(<AuthModal onClose={onClose} />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'x@x.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'wrongpw' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.queryByLabelText(/authenticator code/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/AuthModal.test.tsx
+++ b/packages/app/src/components/AuthModal.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../stores/authStore', () => ({
   useAuthStore: () => ({
     signIn: mockSignIn,
     signUp: mockSignUp,
+    resolveMfaChallenge: vi.fn(),
   }),
 }));
 

--- a/packages/app/src/components/AuthModal.tsx
+++ b/packages/app/src/components/AuthModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import type { MultiFactorResolver } from 'firebase/auth';
 import { useAuthStore } from '../stores/authStore';
 
 interface AuthModalProps {
@@ -8,14 +9,16 @@ interface AuthModalProps {
 }
 
 const FIREBASE_ERRORS: Record<string, string> = {
-  'auth/email-already-in-use':  'An account with this email already exists.',
-  'auth/invalid-email':          'Please enter a valid email address.',
-  'auth/weak-password':          'Password must be at least 8 characters.',
-  'auth/wrong-password':         'Incorrect password. Try again.',
-  'auth/user-not-found':         'No account found for this email.',
-  'auth/too-many-requests':      'Too many attempts — wait a moment and retry.',
-  'auth/network-request-failed': 'Network error. Check your connection.',
-  'auth/invalid-credential':     'Invalid email or password.',
+  'auth/email-already-in-use':        'An account with this email already exists.',
+  'auth/invalid-email':               'Please enter a valid email address.',
+  'auth/weak-password':               'Password must be at least 8 characters.',
+  'auth/wrong-password':              'Incorrect password. Try again.',
+  'auth/user-not-found':              'No account found for this email.',
+  'auth/too-many-requests':           'Too many attempts — wait a moment and retry.',
+  'auth/network-request-failed':      'Network error. Check your connection.',
+  'auth/invalid-credential':          'Invalid email or password.',
+  'auth/invalid-verification-code':   'Incorrect authentication code. Try again.',
+  'auth/code-expired':                'The authentication code has expired. Please retry.',
 };
 
 function friendlyError(err: unknown): string {
@@ -28,16 +31,18 @@ function friendlyError(err: unknown): string {
 }
 
 export function AuthModal({ onClose, required = false }: AuthModalProps) {
-  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [mode, setMode] = useState<'login' | 'register' | 'mfa-challenge'>('login');
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [totpCode, setTotpCode] = useState('');
+  const [mfaResolver, setMfaResolver] = useState<MultiFactorResolver | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  const { signIn, signUp } = useAuthStore();
+  const { signIn, signUp, resolveMfaChallenge } = useAuthStore();
 
   const isLogin = mode === 'login';
 
@@ -61,6 +66,41 @@ export function AuthModal({ onClose, required = false }: AuthModalProps) {
       const code = (err && typeof err === 'object' && 'code' in err)
         ? (err as { code: string }).code
         : null;
+
+      // MFA required — switch to TOTP challenge step
+      if (
+        code === 'auth/multi-factor-auth-required' &&
+        err !== null &&
+        typeof err === 'object' &&
+        'resolver' in err
+      ) {
+        setMfaResolver((err as { resolver: MultiFactorResolver }).resolver);
+        setMode('mfa-challenge');
+        setLoading(false);
+        return;
+      }
+
+      setErrorCode(code);
+      setError(friendlyError(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMfaSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!mfaResolver) return;
+    setError(null);
+    setLoading(true);
+
+    try {
+      await resolveMfaChallenge(mfaResolver, totpCode);
+      setSuccess('Signed in successfully.');
+      setTimeout(() => onClose?.(), 1000);
+    } catch (err) {
+      const code = (err && typeof err === 'object' && 'code' in err)
+        ? (err as { code: string }).code
+        : null;
       setErrorCode(code);
       setError(friendlyError(err));
     } finally {
@@ -69,13 +109,20 @@ export function AuthModal({ onClose, required = false }: AuthModalProps) {
   };
 
   const canClose = !required;
+  const isMfaChallenge = mode === 'mfa-challenge';
+
+  const ariaLabel = isMfaChallenge
+    ? 'Two-factor authentication'
+    : isLogin
+      ? 'Sign in to OpenCAD'
+      : 'Create OpenCAD account';
 
   return (
     <div
       className="auth-modal-overlay"
       role="dialog"
       aria-modal="true"
-      aria-label={isLogin ? 'Sign in to OpenCAD' : 'Create OpenCAD account'}
+      aria-label={ariaLabel}
       onClick={canClose ? (e) => { if (e.target === e.currentTarget) onClose?.(); } : undefined}
     >
       <div className="auth-modal">
@@ -83,102 +130,144 @@ export function AuthModal({ onClose, required = false }: AuthModalProps) {
           <button aria-label="Close" className="modal-close" onClick={onClose}>×</button>
         )}
 
-        <h2 className="auth-title">
-          {isLogin ? 'Sign in to OpenCAD' : 'Create your account'}
-        </h2>
-        {!isLogin && (
-          <p className="auth-subtitle">14-day free trial — no credit card required</p>
-        )}
+        {/* ── MFA TOTP challenge step ────────────────────────────────── */}
+        {isMfaChallenge ? (
+          <>
+            <h2 className="auth-title">Two-Factor Authentication</h2>
+            <p className="auth-subtitle">Enter the 6-digit code from your authenticator app.</p>
 
-        {error && (
-          <div className="auth-msg auth-msg--error" role="alert">
-            {error}
-            {errorCode === 'auth/email-already-in-use' && (
-              <>
-                {' '}
-                <button
-                  className="btn-switch"
-                  onClick={() => { setMode('login'); setError(null); setErrorCode(null); }}
-                >
-                  Log in instead
-                </button>
-              </>
+            {error && (
+              <div className="auth-msg auth-msg--error" role="alert">{error}</div>
             )}
-          </div>
-        )}
-        {success && <div className="auth-msg auth-msg--success" role="status">{success}</div>}
+            {success && <div className="auth-msg auth-msg--success" role="status">{success}</div>}
 
-        <form className="auth-form" onSubmit={handleSubmit} noValidate>
-          {!isLogin && (
-            <div className="form-field">
-              <label htmlFor="auth-name">Full name</label>
-              <input
-                id="auth-name"
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Alex Johnson"
-                autoComplete="name"
-                disabled={loading}
-              />
+            <form className="auth-form" onSubmit={handleMfaSubmit} noValidate>
+              <div className="form-field">
+                <label htmlFor="auth-totp-code">Authenticator code</label>
+                <input
+                  id="auth-totp-code"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]{6}"
+                  maxLength={6}
+                  value={totpCode}
+                  onChange={(e) => setTotpCode(e.target.value)}
+                  placeholder="123456"
+                  autoComplete="one-time-code"
+                  disabled={loading}
+                  autoFocus
+                />
+              </div>
+              <button type="submit" className="btn-auth-submit" disabled={loading}>
+                {loading ? (
+                  <span className="auth-spinner" aria-label="Loading" />
+                ) : (
+                  'Verify'
+                )}
+              </button>
+            </form>
+          </>
+        ) : (
+          /* ── Login / Register step ──────────────────────────────────── */
+          <>
+            <h2 className="auth-title">
+              {isLogin ? 'Sign in to OpenCAD' : 'Create your account'}
+            </h2>
+            {!isLogin && (
+              <p className="auth-subtitle">14-day free trial — no credit card required</p>
+            )}
+
+            {error && (
+              <div className="auth-msg auth-msg--error" role="alert">
+                {error}
+                {errorCode === 'auth/email-already-in-use' && (
+                  <>
+                    {' '}
+                    <button
+                      className="btn-switch"
+                      onClick={() => { setMode('login'); setError(null); setErrorCode(null); }}
+                    >
+                      Log in instead
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+            {success && <div className="auth-msg auth-msg--success" role="status">{success}</div>}
+
+            <form className="auth-form" onSubmit={handleSubmit} noValidate>
+              {!isLogin && (
+                <div className="form-field">
+                  <label htmlFor="auth-name">Full name</label>
+                  <input
+                    id="auth-name"
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Alex Johnson"
+                    autoComplete="name"
+                    disabled={loading}
+                  />
+                </div>
+              )}
+
+              <div className="form-field">
+                <label htmlFor="auth-email">Email address</label>
+                <input
+                  id="auth-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  required
+                  disabled={loading}
+                />
+              </div>
+
+              <div className="form-field">
+                <label htmlFor="auth-password">Password</label>
+                <input
+                  id="auth-password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  autoComplete={isLogin ? 'current-password' : 'new-password'}
+                  minLength={8}
+                  required
+                  disabled={loading}
+                />
+              </div>
+
+              <button type="submit" className="btn-auth-submit" disabled={loading}>
+                {loading ? (
+                  <span className="auth-spinner" aria-label="Loading" />
+                ) : (
+                  isLogin ? 'Sign in' : 'Create free account'
+                )}
+              </button>
+            </form>
+
+            <div className="auth-switch">
+              {isLogin ? (
+                <>
+                  No account?{' '}
+                  <button className="btn-switch" onClick={() => { setMode('register'); setError(null); setErrorCode(null); }}>
+                    Create one free
+                  </button>
+                </>
+              ) : (
+                <>
+                  Already have an account?{' '}
+                  <button className="btn-switch" onClick={() => { setMode('login'); setError(null); setErrorCode(null); }}>
+                    Sign in
+                  </button>
+                </>
+              )}
             </div>
-          )}
-
-          <div className="form-field">
-            <label htmlFor="auth-email">Email address</label>
-            <input
-              id="auth-email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
-              autoComplete="email"
-              required
-              disabled={loading}
-            />
-          </div>
-
-          <div className="form-field">
-            <label htmlFor="auth-password">Password</label>
-            <input
-              id="auth-password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              autoComplete={isLogin ? 'current-password' : 'new-password'}
-              minLength={8}
-              required
-              disabled={loading}
-            />
-          </div>
-
-          <button type="submit" className="btn-auth-submit" disabled={loading}>
-            {loading ? (
-              <span className="auth-spinner" aria-label="Loading" />
-            ) : (
-              isLogin ? 'Sign in' : 'Create free account'
-            )}
-          </button>
-        </form>
-
-        <div className="auth-switch">
-          {isLogin ? (
-            <>
-              No account?{' '}
-              <button className="btn-switch" onClick={() => { setMode('register'); setError(null); setErrorCode(null); }}>
-                Create one free
-              </button>
-            </>
-          ) : (
-            <>
-              Already have an account?{' '}
-              <button className="btn-switch" onClick={() => { setMode('login'); setError(null); setErrorCode(null); }}>
-                Sign in
-              </button>
-            </>
-          )}
-        </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/packages/app/src/components/MFASettingsPanel.test.tsx
+++ b/packages/app/src/components/MFASettingsPanel.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * T-AUTH-007: MFASettingsPanel — QR code display and TOTP enroll/unenroll
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MFASettingsPanel } from './MFASettingsPanel';
+import type { User } from 'firebase/auth';
+
+// ─── Auth store mock ──────────────────────────────────────────────────────────
+
+const mockEnrollTotp = vi.fn();
+const mockVerifyTotpEnrollment = vi.fn();
+const mockUser = {
+  uid: 'user-123',
+  email: 'test@example.com',
+  displayName: 'Test User',
+} as unknown as User;
+
+vi.mock('../stores/authStore', () => ({
+  useAuthStore: () => ({
+    user: mockUser,
+    enrollTotp: mockEnrollTotp,
+    verifyTotpEnrollment: mockVerifyTotpEnrollment,
+  }),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('T-AUTH-007: MFASettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('T-AUTH-007-13: renders "Set up Authenticator" button when user has no MFA enrolled', () => {
+    render(<MFASettingsPanel />);
+    expect(screen.getByRole('button', { name: /set up authenticator/i })).toBeInTheDocument();
+  });
+
+  it('T-AUTH-007-14: clicking "Set up Authenticator" calls enrollTotp and shows QR code URL', async () => {
+    const mockSecret = {
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      generateQrCodeUrl: vi.fn(() => 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP'),
+    };
+    mockEnrollTotp.mockResolvedValue({
+      secret: mockSecret,
+      qrCodeUrl: 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP',
+    });
+
+    render(<MFASettingsPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /set up authenticator/i }));
+
+    await waitFor(() => {
+      expect(mockEnrollTotp).toHaveBeenCalledWith(mockUser);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mfa-qr-code')).toBeInTheDocument();
+    });
+  });
+
+  it('T-AUTH-007-15: shows OTP input and Confirm button after QR code is displayed', async () => {
+    const mockSecret = {
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      generateQrCodeUrl: vi.fn(() => 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP'),
+    };
+    mockEnrollTotp.mockResolvedValue({
+      secret: mockSecret,
+      qrCodeUrl: 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP',
+    });
+
+    render(<MFASettingsPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /set up authenticator/i }));
+
+    await waitFor(() => screen.getByTestId('mfa-qr-code'));
+
+    expect(screen.getByLabelText(/enter code/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument();
+  });
+
+  it('T-AUTH-007-16: confirming OTP calls verifyTotpEnrollment with correct args', async () => {
+    const mockSecret = {
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      generateQrCodeUrl: vi.fn(() => 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP'),
+    };
+    mockEnrollTotp.mockResolvedValue({
+      secret: mockSecret,
+      qrCodeUrl: 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP',
+    });
+    mockVerifyTotpEnrollment.mockResolvedValue(undefined);
+
+    render(<MFASettingsPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /set up authenticator/i }));
+
+    await waitFor(() => screen.getByTestId('mfa-qr-code'));
+
+    fireEvent.change(screen.getByLabelText(/enter code/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(mockVerifyTotpEnrollment).toHaveBeenCalledWith(mockUser, mockSecret, '123456');
+    });
+  });
+
+  it('T-AUTH-007-17: shows success message after successful enrollment', async () => {
+    const mockSecret = {
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      generateQrCodeUrl: vi.fn(() => 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP'),
+    };
+    mockEnrollTotp.mockResolvedValue({
+      secret: mockSecret,
+      qrCodeUrl: 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP',
+    });
+    mockVerifyTotpEnrollment.mockResolvedValue(undefined);
+
+    render(<MFASettingsPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /set up authenticator/i }));
+
+    await waitFor(() => screen.getByTestId('mfa-qr-code'));
+
+    fireEvent.change(screen.getByLabelText(/enter code/i), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('status').textContent).toMatch(/enabled/i);
+  });
+
+  it('T-AUTH-007-18: shows error when verifyTotpEnrollment fails', async () => {
+    const mockSecret = {
+      secretKey: 'JBSWY3DPEHPK3PXP',
+      generateQrCodeUrl: vi.fn(() => 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP'),
+    };
+    mockEnrollTotp.mockResolvedValue({
+      secret: mockSecret,
+      qrCodeUrl: 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP',
+    });
+    mockVerifyTotpEnrollment.mockRejectedValue(
+      Object.assign(new Error('Invalid OTP'), { code: 'auth/invalid-verification-code' }),
+    );
+
+    render(<MFASettingsPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /set up authenticator/i }));
+
+    await waitFor(() => screen.getByTestId('mfa-qr-code'));
+
+    fireEvent.change(screen.getByLabelText(/enter code/i), { target: { value: '000000' } });
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/app/src/components/MFASettingsPanel.tsx
+++ b/packages/app/src/components/MFASettingsPanel.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import type { TotpSecret } from 'firebase/auth';
+import { useAuthStore } from '../stores/authStore';
+
+type EnrollStep = 'idle' | 'qr' | 'success';
+
+export function MFASettingsPanel() {
+  const { user, enrollTotp, verifyTotpEnrollment } = useAuthStore();
+
+  const [step, setStep] = useState<EnrollStep>('idle');
+  const [qrCodeUrl, setQrCodeUrl] = useState<string | null>(null);
+  const [secret, setSecret] = useState<TotpSecret | null>(null);
+  const [otpCode, setOtpCode] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleStartEnrollment = async () => {
+    if (!user) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const result = await enrollTotp(user);
+      if (!result) return; // Firebase not configured
+      setSecret(result.secret);
+      setQrCodeUrl(result.qrCodeUrl);
+      setStep('qr');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start enrollment.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirm = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user || !secret) return;
+    setError(null);
+    setLoading(true);
+    try {
+      await verifyTotpEnrollment(user, secret, otpCode);
+      setStep('success');
+      setOtpCode('');
+    } catch (err) {
+      const code =
+        err !== null && typeof err === 'object' && 'code' in err
+          ? (err as { code: string }).code
+          : null;
+      const message =
+        code === 'auth/invalid-verification-code'
+          ? 'Incorrect code — check your authenticator app and try again.'
+          : err instanceof Error
+            ? err.message
+            : 'Verification failed.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="mfa-settings-panel" aria-labelledby="mfa-heading">
+      <h3 id="mfa-heading">Two-Factor Authentication (TOTP)</h3>
+
+      {error && (
+        <div className="auth-msg auth-msg--error" role="alert">{error}</div>
+      )}
+
+      {step === 'success' && (
+        <div className="auth-msg auth-msg--success" role="status">
+          Authenticator app enabled successfully.
+        </div>
+      )}
+
+      {step === 'idle' && (
+        <button
+          type="button"
+          className="btn-mfa-setup"
+          onClick={handleStartEnrollment}
+          disabled={loading}
+        >
+          {loading ? 'Loading…' : 'Set up Authenticator'}
+        </button>
+      )}
+
+      {step === 'qr' && qrCodeUrl && (
+        <>
+          <p className="mfa-instructions">
+            Scan this QR code with your authenticator app (e.g. Google Authenticator,
+            Authy), then enter the 6-digit code below to confirm.
+          </p>
+          <img
+            data-testid="mfa-qr-code"
+            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(qrCodeUrl)}`}
+            alt="Scan this QR code to set up your authenticator app"
+            width={200}
+            height={200}
+          />
+
+          <form onSubmit={handleConfirm} className="mfa-confirm-form" noValidate>
+            <div className="form-field">
+              <label htmlFor="mfa-otp-code">Enter code</label>
+              <input
+                id="mfa-otp-code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]{6}"
+                maxLength={6}
+                value={otpCode}
+                onChange={(e) => setOtpCode(e.target.value)}
+                placeholder="123456"
+                autoComplete="one-time-code"
+                disabled={loading}
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn-mfa-confirm"
+              disabled={loading || otpCode.length < 6}
+            >
+              {loading ? 'Verifying…' : 'Confirm'}
+            </button>
+          </form>
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/app/src/stores/authStore.mfa.test.ts
+++ b/packages/app/src/stores/authStore.mfa.test.ts
@@ -1,0 +1,255 @@
+/**
+ * T-AUTH-007: MFA TOTP enrollment and challenge resolution
+ *
+ * Tests for enrollTotp, verifyTotpEnrollment, and resolveMfaChallenge actions
+ * added to the authStore.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Firebase auth mocks ────────────────────────────────────────────────────
+
+const mockGenerateSecret = vi.fn();
+const mockAssertionForEnrollment = vi.fn();
+const mockAssertionForSignIn = vi.fn();
+const mockEnroll = vi.fn();
+const mockGetSession = vi.fn(() => Promise.resolve('mock-session'));
+const mockMultiFactorUser = { enroll: mockEnroll, getSession: mockGetSession };
+const mockMultiFactor = vi.fn(() => mockMultiFactorUser);
+
+vi.mock('firebase/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/auth')>();
+  return {
+    ...actual,
+    TotpMultiFactorGenerator: {
+      generateSecret: mockGenerateSecret,
+      assertionForEnrollment: mockAssertionForEnrollment,
+      assertionForSignIn: mockAssertionForSignIn,
+      FACTOR_ID: 'totp',
+    },
+    multiFactor: mockMultiFactor,
+    createUserWithEmailAndPassword: vi.fn(),
+    signInWithEmailAndPassword: vi.fn(),
+    signOut: vi.fn(),
+    onAuthStateChanged: vi.fn((_auth: unknown, cb: (u: null) => void) => {
+      cb(null);
+      return vi.fn();
+    }),
+    updateProfile: vi.fn(),
+    getAuth: vi.fn(),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(),
+  setDoc: vi.fn(),
+  getDoc: vi.fn(() => Promise.resolve({ exists: () => false })),
+  serverTimestamp: vi.fn(),
+  getFirestore: vi.fn(),
+}));
+
+vi.mock('../lib/firebase', () => ({
+  isFirebaseConfigured: true,
+  firebaseAuth: vi.fn(() => ({ currentUser: mockCurrentUser })),
+  firebaseDb: vi.fn(),
+}));
+
+vi.mock('../lib/serverApi', () => ({
+  authApi: { me: vi.fn(() => Promise.resolve()) },
+}));
+
+// ─── Shared mock user ───────────────────────────────────────────────────────
+
+const mockCurrentUser = {
+  uid: 'user-123',
+  email: 'test@example.com',
+  displayName: 'Test User',
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('T-AUTH-007: authStore MFA TOTP actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue('mock-session');
+  });
+
+  describe('enrollTotp()', () => {
+    it('T-AUTH-007-01: returns secret and qrCodeUrl from TotpMultiFactorGenerator', async () => {
+      const mockSecret = {
+        secretKey: 'JBSWY3DPEHPK3PXP',
+        generateQrCodeUrl: vi.fn(() => 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP'),
+      };
+      mockGenerateSecret.mockResolvedValue(mockSecret);
+
+      const { useAuthStore } = await import('./authStore');
+      const store = useAuthStore.getState();
+
+      const result = await store.enrollTotp(mockCurrentUser as unknown as import('firebase/auth').User);
+
+      expect(mockMultiFactor).toHaveBeenCalledWith(mockCurrentUser);
+      expect(mockGetSession).toHaveBeenCalled();
+      expect(mockGenerateSecret).toHaveBeenCalledWith('mock-session');
+      expect(result).toEqual({
+        secret: mockSecret,
+        qrCodeUrl: 'otpauth://totp/OpenCAD:test@example.com?secret=JBSWY3DPEHPK3PXP',
+      });
+    });
+
+    it('T-AUTH-007-02: no-ops gracefully when Firebase is not configured', async () => {
+      vi.doMock('../lib/firebase', () => ({
+        isFirebaseConfigured: false,
+        firebaseAuth: vi.fn(),
+        firebaseDb: vi.fn(),
+      }));
+
+      vi.resetModules();
+      const { useAuthStore } = await import('./authStore');
+      const store = useAuthStore.getState();
+
+      const result = await store.enrollTotp(mockCurrentUser as unknown as import('firebase/auth').User);
+
+      expect(result).toBeNull();
+
+      // Restore
+      vi.doMock('../lib/firebase', () => ({
+        isFirebaseConfigured: true,
+        firebaseAuth: vi.fn(() => ({ currentUser: mockCurrentUser })),
+        firebaseDb: vi.fn(),
+      }));
+      vi.resetModules();
+    });
+  });
+
+  describe('verifyTotpEnrollment()', () => {
+    it('T-AUTH-007-03: calls assertionForEnrollment and enroll with correct args', async () => {
+      const mockSecret = { secretKey: 'JBSWY3DPEHPK3PXP' } as unknown as import('firebase/auth').TotpSecret;
+      const mockAssertion = { factorId: 'totp' };
+      mockAssertionForEnrollment.mockReturnValue(mockAssertion);
+      mockEnroll.mockResolvedValue(undefined);
+
+      const { useAuthStore } = await import('./authStore');
+      const store = useAuthStore.getState();
+
+      await store.verifyTotpEnrollment(
+        mockCurrentUser as unknown as import('firebase/auth').User,
+        mockSecret,
+        '123456',
+      );
+
+      expect(mockAssertionForEnrollment).toHaveBeenCalledWith(mockSecret, '123456');
+      expect(mockMultiFactor).toHaveBeenCalledWith(mockCurrentUser);
+      expect(mockEnroll).toHaveBeenCalledWith(mockAssertion, 'Authenticator');
+    });
+
+    it('T-AUTH-007-04: no-ops gracefully when Firebase is not configured', async () => {
+      vi.doMock('../lib/firebase', () => ({
+        isFirebaseConfigured: false,
+        firebaseAuth: vi.fn(),
+        firebaseDb: vi.fn(),
+      }));
+      vi.resetModules();
+
+      const { useAuthStore } = await import('./authStore');
+      const store = useAuthStore.getState();
+      const mockSecret = { secretKey: 'JBSWY3DPEHPK3PXP' } as unknown as import('firebase/auth').TotpSecret;
+
+      await expect(
+        store.verifyTotpEnrollment(mockCurrentUser as unknown as import('firebase/auth').User, mockSecret, '123456'),
+      ).resolves.toBeUndefined();
+
+      expect(mockAssertionForEnrollment).not.toHaveBeenCalled();
+
+      vi.doMock('../lib/firebase', () => ({
+        isFirebaseConfigured: true,
+        firebaseAuth: vi.fn(() => ({ currentUser: mockCurrentUser })),
+        firebaseDb: vi.fn(),
+      }));
+      vi.resetModules();
+    });
+  });
+
+  describe('resolveMfaChallenge()', () => {
+    it('T-AUTH-007-05: resolves MFA challenge using TotpMultiFactorGenerator.assertionForSignIn', async () => {
+      const mockHint = { factorId: 'totp', uid: 'hint-uid' };
+      const mockResolver = {
+        hints: [mockHint],
+        resolveSignIn: vi.fn().mockResolvedValue({ user: mockCurrentUser }),
+      };
+      const mockAssertion = { factorId: 'totp' };
+      mockAssertionForSignIn.mockReturnValue(mockAssertion);
+
+      const { useAuthStore } = await import('./authStore');
+      const store = useAuthStore.getState();
+
+      await store.resolveMfaChallenge(
+        mockResolver as unknown as import('firebase/auth').MultiFactorResolver,
+        '654321',
+      );
+
+      expect(mockAssertionForSignIn).toHaveBeenCalledWith(mockHint.uid, '654321');
+      expect(mockResolver.resolveSignIn).toHaveBeenCalledWith(mockAssertion);
+    });
+
+    it('T-AUTH-007-06: no-ops gracefully when Firebase is not configured', async () => {
+      vi.doMock('../lib/firebase', () => ({
+        isFirebaseConfigured: false,
+        firebaseAuth: vi.fn(),
+        firebaseDb: vi.fn(),
+      }));
+      vi.resetModules();
+
+      const { useAuthStore } = await import('./authStore');
+      const store = useAuthStore.getState();
+
+      const mockResolver = {
+        hints: [{ factorId: 'totp', uid: 'hint-uid' }],
+        resolveSignIn: vi.fn(),
+      };
+
+      await expect(
+        store.resolveMfaChallenge(
+          mockResolver as unknown as import('firebase/auth').MultiFactorResolver,
+          '654321',
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(mockResolver.resolveSignIn).not.toHaveBeenCalled();
+
+      vi.doMock('../lib/firebase', () => ({
+        isFirebaseConfigured: true,
+        firebaseAuth: vi.fn(() => ({ currentUser: mockCurrentUser })),
+        firebaseDb: vi.fn(),
+      }));
+      vi.resetModules();
+    });
+
+    it('T-AUTH-007-07: resolveSignIn is called with the assertion', async () => {
+      const mockHint = { factorId: 'totp', uid: 'hint-uid' };
+      const mockUser = { ...mockCurrentUser };
+      const mockResolver = {
+        hints: [mockHint],
+        resolveSignIn: vi.fn().mockResolvedValue({ user: mockUser }),
+      };
+      const mockAssertion = { factorId: 'totp' };
+      mockAssertionForSignIn.mockReturnValue(mockAssertion);
+
+      vi.doMock('../lib/firebase', () => ({
+        isFirebaseConfigured: true,
+        firebaseAuth: vi.fn(() => ({ currentUser: mockCurrentUser })),
+        firebaseDb: vi.fn(),
+      }));
+      vi.resetModules();
+
+      const { useAuthStore } = await import('./authStore');
+      const store = useAuthStore.getState();
+
+      await store.resolveMfaChallenge(
+        mockResolver as unknown as import('firebase/auth').MultiFactorResolver,
+        '654321',
+      );
+
+      expect(mockResolver.resolveSignIn).toHaveBeenCalledWith(mockAssertion);
+    });
+  });
+});

--- a/packages/app/src/stores/authStore.ts
+++ b/packages/app/src/stores/authStore.ts
@@ -5,7 +5,11 @@ import {
   signOut as fbSignOut,
   onAuthStateChanged,
   updateProfile,
+  multiFactor,
+  TotpMultiFactorGenerator,
   type User,
+  type TotpSecret,
+  type MultiFactorResolver,
 } from 'firebase/auth';
 import {
   doc,
@@ -28,6 +32,11 @@ export interface UserProfile {
   trialExpiresAt: Date | null;
 }
 
+export interface TotpEnrollmentResult {
+  secret: TotpSecret;
+  qrCodeUrl: string;
+}
+
 interface AuthState {
   status: AuthStatus;
   user: User | null;
@@ -38,6 +47,12 @@ interface AuthState {
   signIn: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
   clearError: () => void;
+  /** Start TOTP enrollment: generates a secret and returns the QR code URL. */
+  enrollTotp: (user: User) => Promise<TotpEnrollmentResult | null>;
+  /** Complete TOTP enrollment by verifying a one-time code. */
+  verifyTotpEnrollment: (user: User, secret: TotpSecret, otp: string) => Promise<void>;
+  /** Resolve a pending MFA sign-in challenge with a TOTP one-time code. */
+  resolveMfaChallenge: (resolver: MultiFactorResolver, otp: string) => Promise<void>;
 }
 
 const TRIAL_DAYS = 14;
@@ -165,5 +180,32 @@ export const useAuthStore = create<AuthState>((set, _get) => {
     },
 
     clearError: () => set({ error: null }),
+
+    enrollTotp: async (user: User): Promise<TotpEnrollmentResult | null> => {
+      if (!isFirebaseConfigured) return null;
+      // firebaseAuth() keeps the auth instance active
+      firebaseAuth();
+      const session = await multiFactor(user).getSession();
+      const secret = await TotpMultiFactorGenerator.generateSecret(session);
+      const qrCodeUrl = secret.generateQrCodeUrl(
+        user.email ?? 'user',
+        'OpenCAD',
+      );
+      return { secret, qrCodeUrl };
+    },
+
+    verifyTotpEnrollment: async (user: User, secret: TotpSecret, otp: string): Promise<void> => {
+      if (!isFirebaseConfigured) return;
+      const assertion = TotpMultiFactorGenerator.assertionForEnrollment(secret, otp);
+      await multiFactor(user).enroll(assertion, 'Authenticator');
+    },
+
+    resolveMfaChallenge: async (resolver: MultiFactorResolver, otp: string): Promise<void> => {
+      if (!isFirebaseConfigured) return;
+      // Use the first TOTP hint (apps with a single second factor)
+      const hint = resolver.hints[0];
+      const assertion = TotpMultiFactorGenerator.assertionForSignIn(hint.uid, otp);
+      await resolver.resolveSignIn(assertion);
+    },
   };
 });


### PR DESCRIPTION
## Summary

- Adds `enrollTotp`, `verifyTotpEnrollment`, and `resolveMfaChallenge` actions to `authStore.ts` using Firebase's `TotpMultiFactorGenerator` and `multiFactor` APIs
- `AuthModal` detects `auth/multi-factor-auth-required` on sign-in and transitions to a TOTP challenge step instead of showing a generic error
- New `MFASettingsPanel` component provides a QR code display flow for enrolling an authenticator app, with OTP confirmation and success/error feedback
- All MFA actions gracefully no-op when `isFirebaseConfigured` is `false` (dev/test mode)
- Updated existing `AuthModal.test.tsx` mock to include the new `resolveMfaChallenge` method

## Test plan

- [x] `T-AUTH-007-01` — `enrollTotp` calls `TotpMultiFactorGenerator.generateSecret` and returns `{ secret, qrCodeUrl }`
- [x] `T-AUTH-007-02` — `enrollTotp` returns `null` when Firebase is not configured
- [x] `T-AUTH-007-03` — `verifyTotpEnrollment` calls `assertionForEnrollment` + `multiFactor(user).enroll`
- [x] `T-AUTH-007-04` — `verifyTotpEnrollment` no-ops when Firebase is not configured
- [x] `T-AUTH-007-05` — `resolveMfaChallenge` calls `assertionForSignIn` + `resolver.resolveSignIn`
- [x] `T-AUTH-007-06` — `resolveMfaChallenge` no-ops when Firebase is not configured
- [x] `T-AUTH-007-07` — `resolver.resolveSignIn` is called with the correct assertion
- [x] `T-AUTH-007-08` — `AuthModal` shows TOTP input when `signIn` throws `auth/multi-factor-auth-required`
- [x] `T-AUTH-007-09` — TOTP challenge step displays "Two-Factor Authentication" heading
- [x] `T-AUTH-007-10` — Submitting TOTP code calls `resolveMfaChallenge` with resolver and OTP
- [x] `T-AUTH-007-11` — Shows error message when TOTP verification fails
- [x] `T-AUTH-007-12` — Non-MFA `signIn` errors still show inline error (no TOTP step)
- [x] `T-AUTH-007-13` — `MFASettingsPanel` renders "Set up Authenticator" button by default
- [x] `T-AUTH-007-14` — Clicking "Set up Authenticator" calls `enrollTotp` and shows QR code
- [x] `T-AUTH-007-15` — QR code step shows OTP input and Confirm button
- [x] `T-AUTH-007-16` — Confirming OTP calls `verifyTotpEnrollment` with correct args
- [x] `T-AUTH-007-17` — Shows success message after successful enrollment
- [x] `T-AUTH-007-18` — Shows error when `verifyTotpEnrollment` fails

All 18 T-AUTH-007 tests pass. Full test suite (139 test files) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)