### PR TITLE
feat(app): wire plugin marketplace to backend API

### DIFF
--- a/packages/app/src/components/MarketplacePanel.tsx
+++ b/packages/app/src/components/MarketplacePanel.tsx
@@ -1,6 +1,13 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { pluginRegistry } from '../plugins/pluginRegistry';
 import { validateManifest, type PluginManifest } from '../plugins/pluginManifest';
+import {
+  listPlugins,
+  listInstalled,
+  installPlugin,
+  uninstallPlugin,
+  type Plugin,
+} from '../lib/marketplaceApi';
 
 export interface MarketplaceItem {
   id: string;
@@ -50,29 +57,142 @@ interface MarketplacePanelProps {
   onPublish?: () => void;
 }
 
+// ─── Loading skeleton ─────────────────────────────────────────────────────────
+
+function PluginSkeleton(): React.ReactElement {
+  return (
+    <div className="marketplace-item skeleton" aria-busy="true">
+      <div className="item-info">
+        <span className="skeleton-line skeleton-name" />
+        <span className="skeleton-line skeleton-desc" />
+        <span className="skeleton-line skeleton-meta" />
+      </div>
+    </div>
+  );
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function MarketplacePanel({ items = [], onInstall, onPublish }: MarketplacePanelProps = {}) {
+export function MarketplacePanel({
+  items = [],
+  onInstall,
+  onPublish,
+}: MarketplacePanelProps = {}) {
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  // API state
+  const [apiPlugins, setApiPlugins] = useState<Plugin[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [installingIds, setInstallingIds] = useState<Set<string>>(new Set());
+  const [uninstallingIds, setUninstallingIds] = useState<Set<string>>(new Set());
+
   // Track which plugin IDs have been installed via the registry during this session
   const [registeredIds, setRegisteredIds] = useState<Set<string>>(
-    () => new Set(pluginRegistry.list().map((m) => m.id))
+    () => new Set(pluginRegistry.list().map((m) => m.id)),
   );
 
-  const filtered = useMemo(() => {
-    const q = search.toLowerCase();
-    return !q ? items : items.filter((item) =>
-      item.name.toLowerCase().includes(q) ||
-      item.description.toLowerCase().includes(q) ||
-      item.category.toLowerCase().includes(q)
-    );
-  }, [items, search]);
+  // ── Debounce search input 300 ms ─────────────────────────────────────────
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [search]);
 
+  // ── Fetch plugins from API ───────────────────────────────────────────────
+  const fetchPlugins = useCallback(async (searchTerm: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [all, installed] = await Promise.all([
+        listPlugins(searchTerm ? { search: searchTerm } : undefined),
+        listInstalled(),
+      ]);
+      const installedIds = new Set(installed.map((p) => p.id));
+      const merged = all.map((p) => ({ ...p, installed: p.installed || installedIds.has(p.id) }));
+      setApiPlugins(merged);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load plugins';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Fetch on mount and when debounced search changes
+  useEffect(() => {
+    void fetchPlugins(debouncedSearch);
+  }, [debouncedSearch, fetchPlugins]);
+
+  // ── Install handler ──────────────────────────────────────────────────────
+  const handleApiInstall = useCallback(async (pluginId: string) => {
+    // Optimistic update
+    setApiPlugins((prev) => prev.map((p) => (p.id === pluginId ? { ...p, installed: true } : p)));
+    setInstallingIds((prev) => new Set([...prev, pluginId]));
+    try {
+      await installPlugin(pluginId);
+    } catch (_err) {
+      // Revert on failure
+      setApiPlugins((prev) =>
+        prev.map((p) => (p.id === pluginId ? { ...p, installed: false } : p)),
+      );
+    } finally {
+      setInstallingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(pluginId);
+        return next;
+      });
+    }
+  }, []);
+
+  // ── Uninstall handler ────────────────────────────────────────────────────
+  const handleApiUninstall = useCallback(async (pluginId: string) => {
+    // Optimistic update
+    setApiPlugins((prev) =>
+      prev.map((p) => (p.id === pluginId ? { ...p, installed: false } : p)),
+    );
+    setUninstallingIds((prev) => new Set([...prev, pluginId]));
+    try {
+      await uninstallPlugin(pluginId);
+    } catch (_err) {
+      // Revert on failure
+      setApiPlugins((prev) =>
+        prev.map((p) => (p.id === pluginId ? { ...p, installed: true } : p)),
+      );
+    } finally {
+      setUninstallingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(pluginId);
+        return next;
+      });
+    }
+  }, []);
+
+  // ── Legacy catalogue install ─────────────────────────────────────────────
   const handleInstallPlugin = (manifest: PluginManifest) => {
     if (!validateManifest(manifest)) return;
     pluginRegistry.register(manifest);
     setRegisteredIds((prev) => new Set([...prev, manifest.id]));
   };
+
+  // ── Filter legacy prop items by search ───────────────────────────────────
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return !q
+      ? items
+      : items.filter(
+          (item) =>
+            item.name.toLowerCase().includes(q) ||
+            item.description.toLowerCase().includes(q) ||
+            item.category.toLowerCase().includes(q),
+        );
+  }, [items, search]);
 
   const installedPlugins = pluginRegistry.list();
 
@@ -95,6 +215,7 @@ export function MarketplacePanel({ items = [], onInstall, onPublish }: Marketpla
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         className="marketplace-search"
+        aria-label="Search plugins"
       />
 
       {/* Legacy prop-based items list */}
@@ -106,7 +227,8 @@ export function MarketplacePanel({ items = [], onInstall, onPublish }: Marketpla
               <span className="item-author">by {item.author}</span>
               <span className="item-desc">{item.description}</span>
               <span className="item-meta">
-                v{item.version} · {item.category} · {item.downloads.toLocaleString('en-US')} downloads
+                v{item.version} · {item.category} · {item.downloads.toLocaleString('en-US')}{' '}
+                downloads
               </span>
             </div>
             {item.installed ? (
@@ -127,32 +249,108 @@ export function MarketplacePanel({ items = [], onInstall, onPublish }: Marketpla
         )}
       </div>
 
-      {/* Available Plugins (catalogue) */}
+      {/* API-backed plugins section */}
       <div className="marketplace-section">
         <h4 className="section-title">Available Plugins</h4>
-        {AVAILABLE_PLUGINS.map((plugin) => {
-          const isInstalled = registeredIds.has(plugin.id);
-          return (
-            <div key={plugin.id} className="marketplace-item">
-              <div className="item-info">
-                <span className="item-name">{plugin.name}</span>
-                <span className="item-desc">{plugin.description}</span>
-                <span className="item-meta">v{plugin.version}</span>
+
+        {/* Error state */}
+        {error && !loading && (
+          <div className="marketplace-error" role="alert">
+            <span>{error}</span>
+            <button className="btn-retry" onClick={() => void fetchPlugins(debouncedSearch)}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* Loading skeleton */}
+        {loading && (
+          <div aria-label="Loading plugins">
+            <PluginSkeleton />
+            <PluginSkeleton />
+            <PluginSkeleton />
+          </div>
+        )}
+
+        {/* Plugin list */}
+        {!loading &&
+          !error &&
+          apiPlugins.map((plugin) => {
+            const isInstalling = installingIds.has(plugin.id);
+            const isUninstalling = uninstallingIds.has(plugin.id);
+            return (
+              <div
+                key={plugin.id}
+                className={`marketplace-item${plugin.installed ? ' installed' : ''}`}
+              >
+                <div className="item-info">
+                  {plugin.icon && (
+                    <img src={plugin.icon} alt={plugin.name} className="plugin-icon" />
+                  )}
+                  <span className="item-name">{plugin.name}</span>
+                  <span className="item-author">by {plugin.author}</span>
+                  <span className="item-desc">{plugin.description}</span>
+                  <span className="item-meta">
+                    v{plugin.version} · {plugin.category} ·{' '}
+                    {plugin.downloadCount.toLocaleString('en-US')} downloads ·{' '}
+                    {plugin.price === 'free' ? 'Free' : `$${plugin.price}`}
+                    {plugin.rating > 0 && ` · ★ ${plugin.rating.toFixed(1)}`}
+                  </span>
+                </div>
+                {plugin.installed ? (
+                  <button
+                    aria-label={`Uninstall ${plugin.name}`}
+                    className="btn-uninstall"
+                    disabled={isUninstalling}
+                    onClick={() => void handleApiUninstall(plugin.id)}
+                  >
+                    {isUninstalling ? 'Removing…' : 'Uninstall'}
+                  </button>
+                ) : (
+                  <button
+                    aria-label={`Install ${plugin.name}`}
+                    className="btn-install"
+                    disabled={isInstalling}
+                    onClick={() => void handleApiInstall(plugin.id)}
+                  >
+                    {isInstalling ? 'Installing…' : 'Install'}
+                  </button>
+                )}
               </div>
-              {isInstalled ? (
-                <span className="installed-badge">Installed</span>
-              ) : (
-                <button
-                  aria-label={`Install ${plugin.name}`}
-                  className="btn-install"
-                  onClick={() => handleInstallPlugin(plugin)}
-                >
-                  Install
-                </button>
-              )}
-            </div>
-          );
-        })}
+            );
+          })}
+
+        {/* Empty state after loading */}
+        {!loading && !error && apiPlugins.length === 0 && (
+          <div className="marketplace-empty">No plugins found.</div>
+        )}
+
+        {/* Fallback catalogue when API failed */}
+        {!loading &&
+          error &&
+          AVAILABLE_PLUGINS.map((plugin) => {
+            const isInstalled = registeredIds.has(plugin.id);
+            return (
+              <div key={plugin.id} className="marketplace-item">
+                <div className="item-info">
+                  <span className="item-name">{plugin.name}</span>
+                  <span className="item-desc">{plugin.description}</span>
+                  <span className="item-meta">v{plugin.version}</span>
+                </div>
+                {isInstalled ? (
+                  <span className="installed-badge">Installed</span>
+                ) : (
+                  <button
+                    aria-label={`Install ${plugin.name}`}
+                    className="btn-install"
+                    onClick={() => handleInstallPlugin(plugin)}
+                  >
+                    Install
+                  </button>
+                )}
+              </div>
+            );
+          })}
       </div>
 
       {/* Registered Plugins section */}

--- a/packages/app/src/lib/marketplaceApi.test.ts
+++ b/packages/app/src/lib/marketplaceApi.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Marketplace API tests
+ * T-MKT-001: listPlugins() calls correct endpoint
+ * T-MKT-002: installPlugin() sends auth header
+ * T-MKT-003: network error → rejects with descriptive message
+ */
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  listPlugins,
+  installPlugin,
+  uninstallPlugin,
+  listInstalled,
+  getPlugin,
+  registerMarketplaceTokenProvider,
+  type Plugin,
+  type InstallResult,
+} from './marketplaceApi';
+
+expect.extend(jestDomMatchers);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makePlugin = (overrides: Partial<Plugin> = {}): Plugin => ({
+  id: 'plugin-1',
+  name: 'Test Plugin',
+  description: 'A test plugin.',
+  category: 'structural',
+  version: '1.0.0',
+  author: 'Tester',
+  rating: 4.5,
+  downloadCount: 1200,
+  price: 'free',
+  installed: false,
+  ...overrides,
+});
+
+function stubFetch(
+  response: Partial<Response> & { json?: () => Promise<unknown> },
+): ReturnType<typeof vi.fn> {
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => '',
+    json: async () => [],
+    ...response,
+  });
+  vi.stubGlobal('fetch', mockFetch);
+  return mockFetch;
+}
+
+// ── T-MKT-001: listPlugins() calls correct endpoint ───────────────────────────
+
+describe('T-MKT-001: listPlugins()', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    registerMarketplaceTokenProvider(async () => null);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls the /api/v1/marketplace/plugins endpoint', async () => {
+    const plugins = [makePlugin()];
+    const mockFetch = stubFetch({ json: async () => plugins });
+
+    const result = await listPlugins();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toMatch(/\/api\/v1\/marketplace\/plugins$/);
+    expect(result).toEqual(plugins);
+  });
+
+  it('appends category query param when provided', async () => {
+    const mockFetch = stubFetch({ json: async () => [] });
+
+    await listPlugins({ category: 'structural' });
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toMatch(/category=structural/);
+  });
+
+  it('appends search query param when provided', async () => {
+    const mockFetch = stubFetch({ json: async () => [] });
+
+    await listPlugins({ search: 'energy' });
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toMatch(/search=energy/);
+  });
+
+  it('appends both category and search when both provided', async () => {
+    const mockFetch = stubFetch({ json: async () => [] });
+
+    await listPlugins({ category: 'mep', search: 'hvac' });
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toMatch(/category=mep/);
+    expect(url).toMatch(/search=hvac/);
+  });
+
+  it('omits query string when no options provided', async () => {
+    const mockFetch = stubFetch({ json: async () => [] });
+
+    await listPlugins();
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).not.toContain('?');
+  });
+
+  it('throws on non-ok HTTP response', async () => {
+    stubFetch({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'Server broke',
+    } as Partial<Response>);
+
+    await expect(listPlugins()).rejects.toThrow(/500/);
+  });
+});
+
+// ── T-MKT-002: installPlugin() sends auth header ──────────────────────────────
+
+describe('T-MKT-002: installPlugin() sends auth header', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends Authorization: Bearer <token> header', async () => {
+    registerMarketplaceTokenProvider(async () => 'test-token-abc');
+    const result: InstallResult = { pluginId: 'plugin-1', installedAt: new Date().toISOString() };
+    const mockFetch = stubFetch({ json: async () => result });
+
+    const installResult = await installPlugin('plugin-1');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer test-token-abc');
+    expect(installResult).toEqual(result);
+  });
+
+  it('sends POST request to correct endpoint', async () => {
+    registerMarketplaceTokenProvider(async () => null);
+    const mockFetch = stubFetch({
+      json: async () => ({ pluginId: 'plugin-2', installedAt: '' }),
+    });
+
+    await installPlugin('plugin-2');
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/api\/v1\/marketplace\/plugins\/plugin-2\/install$/);
+    expect(init?.method).toBe('POST');
+  });
+
+  it('omits Authorization header when no token is available', async () => {
+    registerMarketplaceTokenProvider(async () => null);
+    const mockFetch = stubFetch({
+      json: async () => ({ pluginId: 'plugin-3', installedAt: '' }),
+    });
+
+    await installPlugin('plugin-3');
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('URL-encodes plugin id with special characters', async () => {
+    registerMarketplaceTokenProvider(async () => null);
+    const mockFetch = stubFetch({
+      json: async () => ({ pluginId: 'my plugin/1', installedAt: '' }),
+    });
+
+    await installPlugin('my plugin/1');
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toContain(encodeURIComponent('my plugin/1'));
+  });
+});
+
+// ── T-MKT-003: network error → rejects with descriptive message ───────────────
+
+describe('T-MKT-003: network error rejects with descriptive message', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    registerMarketplaceTokenProvider(async () => null);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listPlugins() rejects with "Marketplace API network error" on fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Failed to fetch')));
+
+    await expect(listPlugins()).rejects.toThrow(/Marketplace API network error/);
+  });
+
+  it('installPlugin() rejects with "Marketplace API network error" on connection refused', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    await expect(installPlugin('plugin-1')).rejects.toThrow(/Marketplace API network error/);
+  });
+
+  it('error message includes the original failure reason', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED')),
+    );
+
+    await expect(listPlugins()).rejects.toThrow(/net::ERR_NAME_NOT_RESOLVED/);
+  });
+
+  it('uninstallPlugin() rejects with descriptive message on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('timeout')));
+
+    await expect(uninstallPlugin('plugin-1')).rejects.toThrow(/Marketplace API network error/);
+  });
+});
+
+// ── Additional coverage: getPlugin and listInstalled ─────────────────────────
+
+describe('getPlugin()', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    registerMarketplaceTokenProvider(async () => null);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches single plugin by id', async () => {
+    const plugin = makePlugin({ id: 'single-plugin' });
+    const mockFetch = stubFetch({ json: async () => plugin });
+
+    const result = await getPlugin('single-plugin');
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toMatch(/\/api\/v1\/marketplace\/plugins\/single-plugin$/);
+    expect(result).toEqual(plugin);
+  });
+});
+
+describe('listInstalled()', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    registerMarketplaceTokenProvider(async () => null);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls /api/v1/marketplace/plugins/installed', async () => {
+    const installed = [makePlugin({ installed: true })];
+    const mockFetch = stubFetch({ json: async () => installed });
+
+    const result = await listInstalled();
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toMatch(/\/api\/v1\/marketplace\/plugins\/installed$/);
+    expect(result).toEqual(installed);
+  });
+});

--- a/packages/app/src/lib/marketplaceApi.ts
+++ b/packages/app/src/lib/marketplaceApi.ts
@@ -1,0 +1,101 @@
+/**
+ * Marketplace API client — typed wrapper for `/api/v1/marketplace` endpoints.
+ *
+ * Auth: Firebase ID token attached via Authorization header.
+ * Base URL: `VITE_API_BASE_URL` + `/api/v1/marketplace` (falls back to `/api/v1/marketplace`).
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface Plugin {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  version: string;
+  author: string;
+  icon?: string;
+  rating: number;
+  downloadCount: number;
+  price: number | 'free';
+  installed: boolean;
+}
+
+export interface InstallResult {
+  pluginId: string;
+  installedAt: string;
+}
+
+// ── Token provider (injected by auth layer at runtime) ────────────────────────
+
+let _getToken: (() => Promise<string | null>) | null = null;
+
+export function registerMarketplaceTokenProvider(fn: () => Promise<string | null>): void {
+  _getToken = fn;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function baseUrl(): string {
+  const viteBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
+  return `${viteBase}/api/v1/marketplace`;
+}
+
+async function authHeaders(): Promise<HeadersInit> {
+  const token = _getToken ? await _getToken().catch(() => null) : null;
+  return token
+    ? { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+    : { 'Content-Type': 'application/json' };
+}
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const headers = await authHeaders();
+  const url = `${baseUrl()}${path}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      ...init,
+      headers: { ...headers, ...(init?.headers ?? {}) },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Marketplace API network error: ${message}`);
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`Marketplace API ${res.status}: ${text}`);
+  }
+  // 204 No Content (uninstall)
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export function listPlugins(options?: { category?: string; search?: string }): Promise<Plugin[]> {
+  const params = new URLSearchParams();
+  if (options?.category) params.set('category', options.category);
+  if (options?.search) params.set('search', options.search);
+  const qs = params.toString() ? `?${params.toString()}` : '';
+  return apiFetch<Plugin[]>(`/plugins${qs}`);
+}
+
+export function getPlugin(id: string): Promise<Plugin> {
+  return apiFetch<Plugin>(`/plugins/${encodeURIComponent(id)}`);
+}
+
+export function installPlugin(id: string): Promise<InstallResult> {
+  return apiFetch<InstallResult>(`/plugins/${encodeURIComponent(id)}/install`, {
+    method: 'POST',
+  });
+}
+
+export function uninstallPlugin(id: string): Promise<void> {
+  return apiFetch<void>(`/plugins/${encodeURIComponent(id)}/uninstall`, {
+    method: 'DELETE',
+  });
+}
+
+export function listInstalled(): Promise<Plugin[]> {
+  return apiFetch<Plugin[]>('/plugins/installed');
+}


### PR DESCRIPTION
## Summary

- Add `packages/app/src/lib/marketplaceApi.ts` — typed API client wrapping `/api/v1/marketplace` endpoints with Firebase token auth injection
- Wire `MarketplacePanel.tsx` to the real API: mount-time fetch, debounced search (300ms), optimistic install/uninstall, loading skeletons, error state with retry
- Add `packages/app/src/lib/marketplaceApi.test.ts` with 16 tests covering `T-MKT-001`, `T-MKT-002`, `T-MKT-003`

## API client (`marketplaceApi.ts`)

- `listPlugins(options?)` — supports `category` and `search` query params
- `getPlugin(id)` — fetch single plugin by ID
- `installPlugin(id)` — POST with auth header
- `uninstallPlugin(id)` — DELETE, handles 204 No Content
- `listInstalled()` — GET installed plugins
- `registerMarketplaceTokenProvider(fn)` — injects Firebase ID token at runtime
- Network errors wrapped with "Marketplace API network error: ..." prefix

## Panel wiring (`MarketplacePanel.tsx`)

- `useEffect` on mount + debounced search (300ms) calls `listPlugins()` + `listInstalled()` in parallel
- Optimistic install: marks as installed immediately, reverts on API failure
- Optimistic uninstall: marks as uninstalled immediately, reverts on API failure
- Loading skeleton while fetching (3 placeholder rows)
- Error alert with Retry button on API failure
- Fallback to local hardcoded catalogue when API errors
- Backwards-compatible: all existing prop-based tests still pass

## Test plan

- [x] `T-MKT-001`: `listPlugins()` calls `/api/v1/marketplace/plugins` with correct query params
- [x] `T-MKT-002`: `installPlugin()` sends `Authorization: Bearer <token>` header when token present
- [x] `T-MKT-003`: network errors reject with `"Marketplace API network error: <reason>"`
- [x] All 1819 existing tests continue to pass (`pnpm --filter=@opencad/app test:unit`)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)