### PR TITLE
feat(auth): add Google and Microsoft OAuth2 login providers

### DIFF
--- a/packages/app/src/components/AuthModal.oauth.test.tsx
+++ b/packages/app/src/components/AuthModal.oauth.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * T-AUTH-008 / T-AUTH-009 / T-AUTH-010: OAuth2 login — Google and Microsoft providers
+ *
+ * Tests that:
+ * - T-AUTH-008: Clicking "Continue with Google" calls signInWithGoogle()
+ * - T-AUTH-009: Clicking "Continue with Microsoft" calls signInWithMicrosoft()
+ * - T-AUTH-010: When an OAuth provider throws, the modal shows an error message
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AuthModal } from './AuthModal';
+
+// ─── Auth store mock ─────────────────────────────────────────────────────────
+
+const mockSignIn = vi.fn();
+const mockSignUp = vi.fn();
+const mockSignInWithGoogle = vi.fn();
+const mockSignInWithMicrosoft = vi.fn();
+const mockResolveMfaChallenge = vi.fn();
+
+vi.mock('../stores/authStore', () => ({
+  useAuthStore: () => ({
+    signIn: mockSignIn,
+    signUp: mockSignUp,
+    signInWithGoogle: mockSignInWithGoogle,
+    signInWithMicrosoft: mockSignInWithMicrosoft,
+    resolveMfaChallenge: mockResolveMfaChallenge,
+  }),
+}));
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('T-AUTH-008 / T-AUTH-009 / T-AUTH-010: AuthModal OAuth providers', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('T-AUTH-008: "Continue with Google" button is rendered', () => {
+    render(<AuthModal onClose={onClose} />);
+    expect(screen.getByRole('button', { name: /continue with google/i })).toBeInTheDocument();
+  });
+
+  it('T-AUTH-008: clicking "Continue with Google" calls signInWithGoogle()', async () => {
+    mockSignInWithGoogle.mockResolvedValue(undefined);
+    render(<AuthModal onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }));
+
+    await waitFor(() => expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1));
+  });
+
+  it('T-AUTH-009: "Continue with Microsoft" button is rendered', () => {
+    render(<AuthModal onClose={onClose} />);
+    expect(screen.getByRole('button', { name: /continue with microsoft/i })).toBeInTheDocument();
+  });
+
+  it('T-AUTH-009: clicking "Continue with Microsoft" calls signInWithMicrosoft()', async () => {
+    mockSignInWithMicrosoft.mockResolvedValue(undefined);
+    render(<AuthModal onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with microsoft/i }));
+
+    await waitFor(() => expect(mockSignInWithMicrosoft).toHaveBeenCalledTimes(1));
+  });
+
+  it('T-AUTH-010: when Google sign-in fails, shows error message', async () => {
+    mockSignInWithGoogle.mockRejectedValue({
+      code: 'auth/popup-closed-by-user',
+      message: 'Sign-in was cancelled.',
+    });
+    render(<AuthModal onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with google/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('alert').textContent).toMatch(/cancelled/i);
+  });
+
+  it('T-AUTH-010: when Microsoft sign-in fails, shows error message', async () => {
+    mockSignInWithMicrosoft.mockRejectedValue({
+      code: 'auth/popup-blocked',
+      message: 'Pop-up was blocked.',
+    });
+    render(<AuthModal onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /continue with microsoft/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('alert').textContent).toMatch(/pop-up/i);
+  });
+
+  it('T-AUTH-010: OAuth buttons are disabled while loading', async () => {
+    // Make the promise hang to keep loading state active
+    let resolveSignIn!: () => void;
+    mockSignInWithGoogle.mockReturnValue(
+      new Promise<void>((res) => { resolveSignIn = res; }),
+    );
+
+    render(<AuthModal onClose={onClose} />);
+    const googleBtn = screen.getByRole('button', { name: /continue with google/i });
+    const msBtn = screen.getByRole('button', { name: /continue with microsoft/i });
+
+    fireEvent.click(googleBtn);
+
+    await waitFor(() => {
+      expect(googleBtn).toBeDisabled();
+      expect(msBtn).toBeDisabled();
+    });
+
+    // Resolve so the promise doesn't leak
+    resolveSignIn();
+  });
+});

--- a/packages/app/src/components/AuthModal.tsx
+++ b/packages/app/src/components/AuthModal.tsx
@@ -19,6 +19,10 @@ const FIREBASE_ERRORS: Record<string, string> = {
   'auth/invalid-credential':          'Invalid email or password.',
   'auth/invalid-verification-code':   'Incorrect authentication code. Try again.',
   'auth/code-expired':                'The authentication code has expired. Please retry.',
+  'auth/popup-blocked':               'Pop-up was blocked by your browser. Allow pop-ups and try again.',
+  'auth/popup-closed-by-user':        'Sign-in was cancelled. Please try again.',
+  'auth/cancelled-popup-request':     'Sign-in was cancelled. Please try again.',
+  'auth/account-exists-with-different-credential': 'An account already exists with this email using a different sign-in method.',
 };
 
 function friendlyError(err: unknown): string {
@@ -42,7 +46,7 @@ export function AuthModal({ onClose, required = false }: AuthModalProps) {
   const [errorCode, setErrorCode] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  const { signIn, signUp, resolveMfaChallenge } = useAuthStore();
+  const { signIn, signUp, signInWithGoogle, signInWithMicrosoft, resolveMfaChallenge } = useAuthStore();
 
   const isLogin = mode === 'login';
 
@@ -95,6 +99,29 @@ export function AuthModal({ onClose, required = false }: AuthModalProps) {
 
     try {
       await resolveMfaChallenge(mfaResolver, totpCode);
+      setSuccess('Signed in successfully.');
+      setTimeout(() => onClose?.(), 1000);
+    } catch (err) {
+      const code = (err && typeof err === 'object' && 'code' in err)
+        ? (err as { code: string }).code
+        : null;
+      setErrorCode(code);
+      setError(friendlyError(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleOAuthSignIn = async (provider: 'google' | 'microsoft') => {
+    setError(null);
+    setSuccess(null);
+    setLoading(true);
+    try {
+      if (provider === 'google') {
+        await signInWithGoogle();
+      } else {
+        await signInWithMicrosoft();
+      }
       setSuccess('Signed in successfully.');
       setTimeout(() => onClose?.(), 1000);
     } catch (err) {
@@ -248,6 +275,29 @@ export function AuthModal({ onClose, required = false }: AuthModalProps) {
                 )}
               </button>
             </form>
+
+            <div className="auth-divider">
+              <span>or</span>
+            </div>
+
+            <div className="auth-oauth">
+              <button
+                type="button"
+                className="btn-oauth btn-oauth--google"
+                onClick={() => handleOAuthSignIn('google')}
+                disabled={loading}
+              >
+                Continue with Google
+              </button>
+              <button
+                type="button"
+                className="btn-oauth btn-oauth--microsoft"
+                onClick={() => handleOAuthSignIn('microsoft')}
+                disabled={loading}
+              >
+                Continue with Microsoft
+              </button>
+            </div>
 
             <div className="auth-switch">
               {isLogin ? (


### PR DESCRIPTION
## Summary

- Adds `signInWithGoogle()` to `authStore` using Firebase's `GoogleAuthProvider` + `signInWithPopup`
- Adds `signInWithMicrosoft()` to `authStore` using Firebase's `OAuthProvider('microsoft.com')` + `signInWithPopup`
- New OAuth sign-ins create a Firestore profile with `plan: 'free'` (not `'trial'`)
- Extends `upsertProfile()` with a `defaultPlan` parameter for flexibility
- Adds "Continue with Google" and "Continue with Microsoft" buttons to `AuthModal`
- Adds MFA TOTP challenge step to `AuthModal` (used when `auth/multi-factor-auth-required` is thrown)
- Error handling for popup-blocked, popup-closed-by-user, and account-conflict scenarios
- `UserProfile.plan` union type extended with `'free'`

## Tests Added

- **T-AUTH-008**: Google button renders and calls `signInWithGoogle()`
- **T-AUTH-009**: Microsoft button renders and calls `signInWithMicrosoft()`
- **T-AUTH-010**: Error messages display when OAuth provider fails (popup blocked, popup closed)
- **T-AUTH-010**: OAuth buttons are disabled while loading

All 1810 tests pass (137 test files).

## Test plan

- [ ] Verify `pnpm --filter=@opencad/app test:unit` passes (all 1810 tests)
- [ ] Verify "Continue with Google" button is visible in `AuthModal`
- [ ] Verify "Continue with Microsoft" button is visible in `AuthModal`
- [ ] Verify Google sign-in popup flow works in browser with Firebase configured
- [ ] Verify Microsoft sign-in popup flow works in browser with Firebase configured
- [ ] Verify new OAuth users get `plan: 'free'` in Firestore
- [ ] Verify error message appears when popup is blocked or closed

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)