### PR TITLE
fix(document): restore truncated exportToIFC function body

### DIFF
--- a/packages/document/src/ifc.ts
+++ b/packages/document/src/ifc.ts
@@ -1099,3 +1099,20 @@ export function exportToIFC(doc: DocumentSchema): string {
     lines.push(`#${sid}=IFCBUILDINGSTOREY('${level.id}',$,'${level.name}',$,$,$,$,$,.ELEMENT.,${level.elevation}.);`);
   }
 
+  const walls = Object.values(doc.content.elements).filter((e) => e.type === 'wall');
+  for (const wall of walls) {
+    const wid = next();
+    const name = (wall.properties['Name']?.value as string) || 'Wall';
+    const storeyRef = wall.levelId && storeyIds[wall.levelId]
+      ? `#${storeyIds[wall.levelId]}`
+      : '$';
+    const bbox = wall.boundingBox;
+    const bboxComment = ` /* bbox:${bbox.min.x},${bbox.min.y},${bbox.min.z}:${bbox.max.x},${bbox.max.y},${bbox.max.z} */`;
+    lines.push(`#${wid}=IFCWALL('${wall.id}',$,'${name}',$,$,${storeyRef},$,$);${bboxComment}`);
+  }
+
+  lines.push('ENDSEC;');
+  lines.push('END-ISO-10303-21;');
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

- Restores the missing body of `exportToIFC()` in `packages/document/src/ifc.ts`
- The function was accidentally truncated during a merge conflict resolution — missing the wall element loop, `ENDSEC`, `END-ISO-10303-21`, and the `return` statement
- This caused `TS1005: '}' expected` at line 1102, blocking all `@opencad/document` typecheck and CI

## Test plan

- [ ] `pnpm --filter=@opencad/document typecheck` passes
- [ ] `pnpm --filter=@opencad/document test:unit` passes (T-IO-002/003/004 tests)
- [ ] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)