### PR TITLE
fix(app): remove duplicate declarations from rebase merge conflicts

### DIFF
--- a/packages/app/src/hooks/useTauri.ts
+++ b/packages/app/src/hooks/useTauri.ts
@@ -9,6 +9,7 @@
  * T-DSK-012: checkForUpdates() — call Tauri updater plugin
  */
 
+import { useState, useEffect } from 'react';
 import type { DocumentSchema } from '@opencad/document';
 
 declare global {
@@ -209,25 +210,7 @@ export async function tauriCheckForUpdate(): Promise<TauriUpdateStatus> {
   return invoke<TauriUpdateStatus>('check_for_update');
 }
 
-/** T-DSK-012: Check for available app updates via the Tauri updater plugin. */
-export interface UpdaterInfo {
-  version: string;
-  body: string;
-  date: string;
-}
-
-export async function checkForUpdates(): Promise<UpdaterInfo | null> {
-  if (!isTauri()) return null;
-  try {
-    return await window.__TAURI__!.core.invoke<UpdaterInfo>('plugin:updater|check');
-  } catch {
-    return null;
-  }
-}
-
 // ─── React hook ──────────────────────────────────────────────
-
-import { useState, useEffect } from 'react';
 
 export interface TauriState {
   isDesktop: boolean;

--- a/packages/app/src/hooks/useViewport.ts
+++ b/packages/app/src/hooks/useViewport.ts
@@ -200,8 +200,6 @@ export function useViewport({ isViewOnly = false }: UseViewportOptions = {}) {
   const [snapEnabled, setSnapEnabled] = useState(true);
   const [currentSnap, setCurrentSnap] = useState<SnapResult | null>(null);
   const [zoomScale, setZoomScale] = useState(1);
-  const [drawingText, setDrawingText] = useState<Point | null>(null);
-  const textInputRef = useRef<HTMLInputElement>(null);
 
   // ─── Text tool state ────────────────────────────────────────────────────────
   // When the user clicks with the text tool active, drawingText records the
@@ -498,37 +496,6 @@ export function useViewport({ isViewOnly = false }: UseViewportOptions = {}) {
   }, [doc, addElement, toolParams]);
 
   // ─── Text tool: confirm / cancel ──────────────────────────────────────────
-
-  /** Called when the user presses Enter or blurs the text overlay input. */
-  const confirmText = useCallback((content: string) => {
-    if (!drawingText) return;
-    const pos = drawingText;
-    setDrawingText(null);
-
-    const trimmed = content.trim();
-    if (!trimmed) return; // empty input — cancel silently
-
-    if (!doc) return;
-    const layerId = Object.keys(doc.organization.layers)[0] || 'default';
-    const textData: TextGeometryData = {
-      x: pos.x, y: pos.y,
-      content: trimmed,
-      fontSize: 14,
-      fontFamily: 'sans-serif',
-    };
-    addElement({
-      type: 'text',
-      layerId,
-      geometry: { type: 'point', data: textData as unknown as Record<string, unknown> },
-      properties: { Name: { type: 'string', value: 'Text' } },
-    });
-    getStoreActions().pushHistory('Add text');
-  }, [drawingText, doc, addElement]);
-
-  /** Called when the user presses Escape on the text overlay input. */
-  const cancelText = useCallback(() => {
-    setDrawingText(null);
-  }, []);
 
   // ─── Canvas draw loop ─────────────────────────────────────────────────────
 

--- a/packages/app/src/stores/documentStore.ts
+++ b/packages/app/src/stores/documentStore.ts
@@ -80,7 +80,6 @@ interface DocumentState {
     layerId: string;
     geometry?: { type: string; data: unknown };
     properties?: Record<string, unknown>;
-    geometry?: { type: string; data: unknown };
   }) => string;
   updateElement: (elementId: string, updates: Record<string, unknown>) => void;
   deleteElement: (elementId: string) => void;
@@ -110,10 +109,6 @@ interface DocumentState {
   deleteLevel: (levelId: string) => void;
   renameLevel: (levelId: string, name: string) => void;
   renameProject: (name: string) => void;
-
-  /** Design review workflow status */
-  reviewStatus: 'none' | 'pending' | 'approved' | 'changes_requested';
-  setReviewStatus: (status: 'none' | 'pending' | 'approved' | 'changes_requested') => void;
 }
 
 export const useDocumentStore = create<DocumentState>()(
@@ -146,9 +141,6 @@ export const useDocumentStore = create<DocumentState>()(
       },
 
       changeHistory: [],
-
-      reviewStatus: 'none',
-      setReviewStatus: (status) => set({ reviewStatus: status }),
 
       initProject: (projectId, userId) => {
         let model: DocumentModel;
@@ -598,9 +590,6 @@ export const useDocumentStore = create<DocumentState>()(
         model.documentData.metadata.updatedAt = Date.now();
         set({ document: { ...model.documentData } });
       },
-
-      reviewStatus: 'none' as const,
-      setReviewStatus: (status) => set({ reviewStatus: status }),
 
       renameProject: (name) => {
         const { model } = get();


### PR DESCRIPTION
## Summary

Removes 4 sets of duplicate declarations introduced when PR #283 was rebased onto a main branch that already contained the same code from earlier PRs:

- **`useViewport.ts`**: duplicate `drawingText`/`setDrawingText`/`textInputRef` state + `confirmText`/`cancelText` callbacks (PR #283 added stubs; PR #275 text-tool already had the real implementation)
- **`useTauri.ts`**: duplicate `checkForUpdates` export + misplaced React import in the middle of the file (PR #283 added stubs; PR #276 auto-update already had the real implementation)
- **`documentStore.ts`**: duplicate `reviewStatus`/`setReviewStatus` in the interface (×2) and implementation (×3)

## Test plan

- [ ] `pnpm --filter=@opencad/app typecheck` passes
- [ ] `pnpm --filter=@opencad/app test:unit` passes
- [ ] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)