### PR TITLE
test(auth): add registerTokenProvider to serverApi mock in MFA tests

### DIFF
--- a/packages/app/src/stores/authStore.mfa.test.ts
+++ b/packages/app/src/stores/authStore.mfa.test.ts
@@ -56,6 +56,7 @@ vi.mock('../lib/firebase', () => ({
 
 vi.mock('../lib/serverApi', () => ({
   authApi: { me: vi.fn(() => Promise.resolve()) },
+  registerTokenProvider: vi.fn(),
 }));
 
 // ─── Shared mock user ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `authStore.ts` calls `registerTokenProvider()` at store initialisation (added in #283)
- `authStore.mfa.test.ts` mocked `../lib/serverApi` without including `registerTokenProvider`, causing vitest to throw on every test in that file
- Adds `registerTokenProvider: vi.fn()` to the serverApi mock factory — 1-line fix, 4 tests now pass

## Test plan
- [ ] `pnpm --filter=@opencad/app test:unit` passes (was 4 failing, now 0)
- [ ] `pnpm ci:local` passes end-to-end

Closes the regression introduced by #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)