### PR TITLE
fix(ci): add Cloud SQL instance to Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,7 @@ jobs:
             --cpu=1 \
             --min-instances=0 \
             --max-instances=10 \
+            --add-cloudsql-instances=opencad-prod:us-central1:opencad-db \
             --set-env-vars="DATABASE_URL=${{ secrets.DATABASE_URL }},AUTH_ENABLED=true,JWT_SECRET=${{ secrets.JWT_SECRET }},STORAGE_BACKEND=gcs,GCS_BUCKET=${{ vars.GCS_BUCKET }},CORS_ORIGINS=https://opencad.archi" \
             --quiet
 


### PR DESCRIPTION
## Summary

- Cloud Run container was failing to start because `DATABASE_URL` pointed to `localhost`
- `--add-cloudsql-instances=opencad-prod:us-central1:opencad-db` injects the Cloud SQL Auth Proxy sidecar so the server can reach the DB via Unix socket
- `DATABASE_URL` GitHub secret updated separately to use `?host=/cloudsql/opencad-prod:us-central1:opencad-db`
- Granted `firebase-adminsdk-fbsvc` the `roles/run.viewer` IAM role so Firebase Hosting can verify the Cloud Run rewrite target

## Test plan
- [ ] Cloud Run service starts and passes health check
- [ ] Firebase Hosting deploy succeeds (Cloud Run service now exists + SA has viewer)
- [ ] `https://opencad.archi` serves the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)