### PR TITLE
fix(ci): pass CLOUD_SQL_INSTANCE env var to Cloud Run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs:
             --min-instances=0 \
             --max-instances=10 \
             --add-cloudsql-instances=opencad-prod:us-central1:opencad-db \
-            --set-env-vars="DATABASE_URL=${{ secrets.DATABASE_URL }},AUTH_ENABLED=true,JWT_SECRET=${{ secrets.JWT_SECRET }},STORAGE_BACKEND=gcs,GCS_BUCKET=${{ vars.GCS_BUCKET }},CORS_ORIGINS=https://opencad.archi" \
+            --set-env-vars="DATABASE_URL=${{ secrets.DATABASE_URL }},CLOUD_SQL_INSTANCE=opencad-prod:us-central1:opencad-db,AUTH_ENABLED=true,JWT_SECRET=${{ secrets.JWT_SECRET }},STORAGE_BACKEND=gcs,GCS_BUCKET=${{ vars.GCS_BUCKET }},CORS_ORIGINS=https://opencad.archi" \
             --quiet
 
   # ── 3. Build frontend & deploy to Firebase Hosting ───────────────────────────


### PR DESCRIPTION
## Summary

- The server's `db.rs` checks `CLOUD_SQL_INSTANCE` and calls `.socket(\"/cloudsql/<instance>\")` to route DB connections through the Cloud SQL Auth Proxy sidecar (injected by `--add-cloudsql-instances` from #289)
- Without the env var, the code fell through to the localhost URL and the container crashed on startup
- One-line addition to `--set-env-vars`: `CLOUD_SQL_INSTANCE=opencad-prod:us-central1:opencad-db`

## Test plan
- [ ] Cloud Run revision starts and health check passes
- [ ] Firebase Hosting deploy succeeds (rewrite target now exists)
- [ ] `https://opencad.archi` serves the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)