### PR TITLE
fix(ci): add FIREBASE_PROJECT_ID and GITHUB_TOKEN to Cloud Run env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs:
             --min-instances=0 \
             --max-instances=10 \
             --add-cloudsql-instances=opencad-prod:us-central1:opencad-db \
-            --set-env-vars="DATABASE_URL=${{ secrets.DATABASE_URL }},CLOUD_SQL_INSTANCE=opencad-prod:us-central1:opencad-db,AUTH_ENABLED=true,JWT_SECRET=${{ secrets.JWT_SECRET }},STORAGE_BACKEND=gcs,GCS_BUCKET=${{ vars.GCS_BUCKET }},CORS_ORIGINS=https://opencad.archi" \
+            --set-env-vars="DATABASE_URL=${{ secrets.DATABASE_URL }},CLOUD_SQL_INSTANCE=opencad-prod:us-central1:opencad-db,AUTH_ENABLED=true,FIREBASE_PROJECT_ID=${{ vars.VITE_FIREBASE_PROJECT_ID }},JWT_SECRET=${{ secrets.JWT_SECRET }},STORAGE_BACKEND=gcs,GCS_BUCKET=${{ vars.GCS_BUCKET }},CORS_ORIGINS=https://opencad.archi,GITHUB_TOKEN=${{ secrets.OPENCAD_GITHUB_TOKEN }},GITHUB_REPO=CariHQ/opencad" \
             --quiet
 
   # ── 3. Build frontend & deploy to Firebase Hosting ───────────────────────────


### PR DESCRIPTION
## Summary

- Server exits at startup when `AUTH_ENABLED=true` without `FIREBASE_PROJECT_ID` (needed to verify Firebase ID tokens)
- Adds `FIREBASE_PROJECT_ID` sourced from the existing `VITE_FIREBASE_PROJECT_ID` variable (`opencad-prod`)
- Also wires `GITHUB_TOKEN` + `GITHUB_REPO` (both already in Secret Manager) for the feedback→GitHub issue feature

## Test plan
- [ ] Cloud Run revision starts and health check passes
- [ ] `GET /health` returns 200
- [ ] Firebase Hosting deploy completes (rewrite target exists)
- [ ] `https://opencad.archi` serves the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)