### PR TITLE
fix(app): correct coordinate save in PropertiesPanel

### DIFF
--- a/packages/app/src/components/PropertiesPanel.test.tsx
+++ b/packages/app/src/components/PropertiesPanel.test.tsx
@@ -4,12 +4,16 @@
  */
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { PropertiesPanel } from './PropertiesPanel';
 import { useDocumentStore } from '../stores/documentStore';
+import * as threeViewport from '../hooks/useThreeViewport';
 expect.extend(jestDomMatchers);
 
 vi.mock('../stores/documentStore');
+vi.mock('../hooks/useThreeViewport', () => ({
+  getSharedSelectedCoords: vi.fn(() => null),
+}));
 
 const mockUseDocumentStore = vi.mocked(useDocumentStore);
 
@@ -102,6 +106,45 @@ describe('T-UI-003: PropertiesPanel', () => {
       'el-1',
       expect.objectContaining({ transform: expect.objectContaining({}) })
     );
+  });
+
+  it('saves correct translation offset when liveCoords shows absolute position', async () => {
+    // Element with translation.x = 10 placed at base posX = 490 → absolute = 500.
+    // User sees "500" in the X field (from liveCoords). Types "600" (wants absolute 600).
+    // Expected: translation.x = 600 - 490 = 110 (not 600!).
+    vi.useFakeTimers();
+    vi.mocked(threeViewport.getSharedSelectedCoords).mockReturnValue({
+      elementId: 'el-1',
+      x: 500,  // absolute = posX(490) + translation.x(10)
+      y: 0,
+      z: 0,
+    });
+    const elementWithOffset = {
+      ...mockElement,
+      transform: { ...mockElement.transform, translation: { x: 10, y: 0, z: 0 } },
+    };
+    const docWithOffset = {
+      ...mockDoc,
+      content: { ...mockDoc.content, elements: { 'el-1': elementWithOffset } },
+    };
+    const store = makeStore({ document: docWithOffset });
+    mockUseDocumentStore.mockReturnValue(store as ReturnType<typeof useDocumentStore>);
+    render(<PropertiesPanel />);
+    // Advance time so the 100ms interval fires and sets liveCoords
+    act(() => { vi.advanceTimersByTime(200); });
+    const xInput = screen.getByDisplayValue('500');
+    fireEvent.focus(xInput);
+    fireEvent.change(xInput, { target: { value: '600' } });
+    fireEvent.blur(xInput);
+    expect(store.updateElement).toHaveBeenCalledWith(
+      'el-1',
+      expect.objectContaining({
+        transform: expect.objectContaining({
+          translation: expect.objectContaining({ x: 110 }),
+        }),
+      })
+    );
+    vi.useRealTimers();
   });
 
   it('calls updateElement and pushHistory when a property value is changed', () => {

--- a/packages/app/src/components/PropertiesPanel.tsx
+++ b/packages/app/src/components/PropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDocumentStore } from '../stores/documentStore';
 import type { PropertyValue, PropertySet } from '@opencad/document';
@@ -72,9 +72,14 @@ export function PropertiesPanel() {
   // update while the user drags the TransformControls gizmo — otherwise we'd
   // only see the value after the drag commits.
   const [liveCoords, setLiveCoords] = useState<{ x: number; y: number; z: number; elementId: string } | null>(null);
+  // Pause live-coord polling while a coord input has focus — prevents the
+  // key from changing (which would unmount the input) while the user types.
+  const coordFocusedRef = useRef(false);
   useEffect(() => {
     const id = setInterval(() => {
-      setLiveCoords(getSharedSelectedCoords());
+      if (!coordFocusedRef.current) {
+        setLiveCoords(getSharedSelectedCoords());
+      }
     }, 100);
     return () => clearInterval(id);
   }, []);
@@ -113,15 +118,23 @@ export function PropertiesPanel() {
   if (!selectedElement) return null;
 
   const handleTranslationBlur = (axis: 'x' | 'y' | 'z', rawValue: string) => {
+    coordFocusedRef.current = false;
     const num = parseFloat(rawValue);
     if (isNaN(num)) return;
     pushHistory(`Move element`);
+    // liveCoords exposes absolute position (base_pos + translation). The user
+    // types an absolute target value, so we must back-compute the translation
+    // offset: new_translation = typed_absolute - base_pos
+    // base_pos = liveCoords[axis] - current_translation[axis]
+    const currentTrans = selectedElement.transform.translation[axis];
+    const liveVal = liveCoords?.elementId === selectedIds[0] ? liveCoords[axis] : null;
+    const newTranslation = liveVal !== null ? num - (liveVal - currentTrans) : num;
     updateElement(selectedIds[0], {
       transform: {
         ...selectedElement.transform,
         translation: {
           ...selectedElement.transform.translation,
-          [axis]: num,
+          [axis]: newTranslation,
         },
       },
     });
@@ -247,10 +260,9 @@ export function PropertiesPanel() {
                   <input
                     type="number"
                     className="property-input"
-                    // key forces re-render when the backing value changes,
-                    // letting the user still type and commit on blur
                     key={`${selectedIds[0]}-${axis}-${live ?? selectedElement.transform.translation[axis]}`}
                     defaultValue={value}
+                    onFocus={() => { coordFocusedRef.current = true; }}
                     onBlur={(e) => handleTranslationBlur(axis, e.target.value)}
                   />
                 </div>


### PR DESCRIPTION
## Summary

- **Bug 1 (critical):** The Location X/Y/Z fields displayed absolute position (`base_pos + translation`) via `liveCoords`, but `handleTranslationBlur` saved the typed value directly as `translation[axis]`. Typing "500" when the element was at absolute 500 (translation=0) would save `translation=500`, jumping the element to `base_pos + 500`.
- **Bug 2:** The 100ms `liveCoords` poll could change the input's `key` prop mid-type, unmounting the input and losing the typed value.

## Fix

- **Coordinate conversion:** `new_translation = typed_absolute - (liveCoords[axis] - current_translation[axis])` — backs out the base position so typing an absolute coordinate lands the element exactly there.
- **Focus guard:** `coordFocusedRef` pauses the live-coord interval while any coordinate input is focused, preventing key-driven remounts during typing.
- **Test:** Added `T-UI-003` case with fake timers that verifies the `abs → offset` conversion when `liveCoords` is active.

## Test plan

- [ ] Place a rectangle/wall, select it — note X/Y in properties panel
- [ ] Type a new X value and blur — element should move to exactly that absolute X position
- [ ] Verify value persists after page refresh
- [ ] Verify TransformControls drag still updates the panel live

🤖 Generated with [Claude Code](https://claude.com/claude-code)